### PR TITLE
use php.net as host, to allow mirror redirects

### DIFF
--- a/5.3/Dockerfile
+++ b/5.3/Dockerfile
@@ -12,8 +12,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.3/apache/Dockerfile
+++ b/5.3/apache/Dockerfile
@@ -12,8 +12,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -11,8 +11,8 @@ RUN set -x \
 	&& dpkg -i libbison-dev_2.7.1.dfsg-1_amd64.deb \
 	&& dpkg -i bison_2.7.1.dfsg-1_amd64.deb \
 	&& rm *.deb \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
-	&& curl -SL "http://us2.php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
+	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
 	&& tar -xvf php.tar.bz2 -C /usr/src/php --strip-components=1 \


### PR DESCRIPTION
This change prevents us2.php.net from getting all of the traffic, and hopefully will provide a more geographically suitable mirror for the download.
