### PR TITLE
Add more tags, thanks to Jérôme

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -21,9 +21,14 @@ for version in "${versions[@]}"; do
 	
 	echo
 	for va in "${versionAliases[@]}"; do
-		if [ "$va" != 'latest' ]; then
+		if [ "$va" = 'latest' ]; then
+			va='cli'
+		else
 			va="$va-cli"
 		fi
+		echo "$va: ${url}@${commit} $version"
+	done
+	for va in "${versionAliases[@]}"; do
 		echo "$va: ${url}@${commit} $version"
 	done
 	


### PR DESCRIPTION
@jpetazzo was whining that he wanted `php:cli` to match `php:apache` and I was like, "we already have that!"

Turns out we didn't.  Whoops.

``` console
$ ./generate-stackbrew-library.sh
# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)

5.3.29-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
5.3-cli: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
5.3.29: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3
5.3: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3

5.3.29-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3/apache
5.3-apache: git://github.com/docker-library/php@7819c242fd0521684b31ff0b33707132ca1bd9c6 5.3/apache

5.4.33-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
5.4-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
5.4.33: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4
5.4: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4

5.4.33-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4/apache
5.4-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.4/apache

5.5.17-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
5.5-cli: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
5.5.17: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5
5.5: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5

5.5.17-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5/apache
5.5-apache: git://github.com/docker-library/php@fbac56b1889188f9dd5d124a0fefca7aa1058aa2 5.5/apache

5.6.1-cli: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
5.6-cli: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
5-cli: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
cli: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
5.6.1: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
5.6: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
5: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6
latest: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6

5.6.1-apache: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6/apache
5.6-apache: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6/apache
5-apache: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6/apache
apache: git://github.com/docker-library/php@28bebceb07d8c70702e83f6f0942edb6dcc7514d 5.6/apache
```
