### PR TITLE
Build mysql as shared extension for PHP 5.5 and 5.6

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x \
 		$(command -v apxs2 > /dev/null 2>&1 && echo '--with-apxs2' || true) \
 		--with-curl \
 		--with-gd \
-		--with-mysql \
+		--with-mysql=shared \
 		--with-mysqli \
 		--with-openssl \
 		--with-pdo-mysql \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 		$(command -v apxs2 > /dev/null 2>&1 && echo '--with-apxs2' || true) \
 		--with-curl \
 		--with-gd \
-		--with-mysql \
+		--with-mysql=shared \
 		--with-mysqli \
 		--with-openssl \
 		--with-pdo-mysql \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x \
 		$(command -v apxs2 > /dev/null 2>&1 && echo '--with-apxs2' || true) \
 		--with-curl \
 		--with-gd \
-		--with-mysql \
+		--with-mysql=shared \
 		--with-mysqli \
 		--with-openssl \
 		--with-pdo-mysql \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 		$(command -v apxs2 > /dev/null 2>&1 && echo '--with-apxs2' || true) \
 		--with-curl \
 		--with-gd \
-		--with-mysql \
+		--with-mysql=shared \
 		--with-mysqli \
 		--with-openssl \
 		--with-pdo-mysql \


### PR DESCRIPTION
Updated Dockerfiles for PHP 5.5 and 5.6 to build mysql as a shared extension and not enable it by default.
The mysql extension is deprecated since PHP 5.5 and using it is discouraged.

Users requiring the mysql extension can still enable it by adding `extension=mysql.so` to their php.ini, which should be added to the README because this breaks backwards compatibility with previous versions of this image.

closes #28
