### PR TITLE
Add --enable-soap

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -34,6 +34,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
+		--enable-soap \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -47,6 +47,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
+		--enable-soap \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -34,6 +34,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
+		--enable-soap \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -47,6 +47,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
+		--enable-soap \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -34,6 +34,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
+		--enable-soap \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -47,6 +47,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
+		--enable-soap \
 		--with-curl \
 		--with-gd \
 		--with-mysql \


### PR DESCRIPTION
I was trying to use the `php` base image with some code that required `SoapClient`. Adding `--enable-soap` to the builds makes this functionality available (cf. http://php.net/manual/en/soap.installation.php).
