### PR TITLE
Build SOAP extension as shared instead of static

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -34,7 +34,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
-		--enable-soap \
+		--enable-soap=shared \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
-		--enable-soap \
+		--enable-soap=shared \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -34,7 +34,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
-		--enable-soap \
+		--enable-soap=shared \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
-		--enable-soap \
+		--enable-soap=shared \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -34,7 +34,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
-		--enable-soap \
+		--enable-soap=shared \
 		--with-curl \
 		--with-gd \
 		--with-mysql \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -47,7 +47,7 @@ RUN buildDeps=" \
 	&& cd /usr/src/php \
 	&& ./configure --disable-cgi \
 		$PHP_EXTRA_CONFIGURE_ARGS \
-		--enable-soap \
+		--enable-soap=shared \
 		--with-curl \
 		--with-gd \
 		--with-mysql \


### PR DESCRIPTION
Updates the changes in #35 to build SOAP extension as shared instead of static.
