### PR TITLE
Make the root more obvious, fix DirectoryIndex to php first

### DIFF
--- a/5.4/apache/apache2.conf
+++ b/5.4/apache/apache2.conf
@@ -36,6 +36,8 @@ Listen 80
 	Require all granted
 </Directory>
 
+DocumentRoot /var/www/html
+
 AccessFileName .htaccess
 <FilesMatch "^\.ht">
 	Require all denied
@@ -52,6 +54,9 @@ CustomLog /proc/self/fd/1 combined
 <FilesMatch \.php$>
 	SetHandler application/x-httpd-php
 </FilesMatch>
-DirectoryIndex index.php
 
-DocumentRoot /var/www/html
+# Multiple DirectoryIndex directives within the same context will add
+# to the list of resources to look for rather than replace
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+DirectoryIndex disabled
+DirectoryIndex index.php index.html

--- a/5.5/apache/apache2.conf
+++ b/5.5/apache/apache2.conf
@@ -36,6 +36,8 @@ Listen 80
 	Require all granted
 </Directory>
 
+DocumentRoot /var/www/html
+
 AccessFileName .htaccess
 <FilesMatch "^\.ht">
 	Require all denied
@@ -52,6 +54,9 @@ CustomLog /proc/self/fd/1 combined
 <FilesMatch \.php$>
 	SetHandler application/x-httpd-php
 </FilesMatch>
-DirectoryIndex index.php
 
-DocumentRoot /var/www/html
+# Multiple DirectoryIndex directives within the same context will add
+# to the list of resources to look for rather than replace
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+DirectoryIndex disabled
+DirectoryIndex index.php index.html

--- a/5.6/apache/apache2.conf
+++ b/5.6/apache/apache2.conf
@@ -36,6 +36,8 @@ Listen 80
 	Require all granted
 </Directory>
 
+DocumentRoot /var/www/html
+
 AccessFileName .htaccess
 <FilesMatch "^\.ht">
 	Require all denied
@@ -52,6 +54,9 @@ CustomLog /proc/self/fd/1 combined
 <FilesMatch \.php$>
 	SetHandler application/x-httpd-php
 </FilesMatch>
-DirectoryIndex index.php
 
-DocumentRoot /var/www/html
+# Multiple DirectoryIndex directives within the same context will add
+# to the list of resources to look for rather than replace
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+DirectoryIndex disabled
+DirectoryIndex index.php index.html

--- a/apache2.conf
+++ b/apache2.conf
@@ -36,6 +36,8 @@ Listen 80
 	Require all granted
 </Directory>
 
+DocumentRoot /var/www/html
+
 AccessFileName .htaccess
 <FilesMatch "^\.ht">
 	Require all denied
@@ -52,6 +54,9 @@ CustomLog /proc/self/fd/1 combined
 <FilesMatch \.php$>
 	SetHandler application/x-httpd-php
 </FilesMatch>
-DirectoryIndex index.php
 
-DocumentRoot /var/www/html
+# Multiple DirectoryIndex directives within the same context will add
+# to the list of resources to look for rather than replace
+# https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+DirectoryIndex disabled
+DirectoryIndex index.php index.html


### PR DESCRIPTION
Server will now prefer `index.php` over `index.html`.
