### PR TITLE
Missing dependency for bz2 ext

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -20,6 +20,7 @@ ENV PHP_VERSION 5.4.35
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
+		libbz2-dev \
 		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -20,6 +20,7 @@ ENV PHP_VERSION 5.5.19
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
+		libbz2-dev \
 		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -20,6 +20,7 @@ ENV PHP_VERSION 5.6.3
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
+		libbz2-dev \
 		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \


### PR DESCRIPTION
Fix for https://github.com/docker-library/php/issues/47
