### PR TITLE
[5.4][fpm][php-fpm.conf] Impossible to listen on [::]:9000. Replace by 9...

### DIFF
--- a/5.4/fpm/php-fpm.conf
+++ b/5.4/fpm/php-fpm.conf
@@ -14,7 +14,7 @@ access.log = /proc/self/fd/2
 user = www-data
 group = www-data
 
-listen = [::]:9000
+listen = 9000
 
 pm = dynamic
 pm.max_children = 5


### PR DESCRIPTION
[5.4][fpm][php-fpm.conf] Impossible to listen on [::]:9000. Replace by 9000

When I execute

``` bash
docker run php:5.4-fpm
```

I have an error thrown.

``` bash
[11-Dec-2014 14:55:32] ERROR: invalid port value ':]:9000'
[11-Dec-2014 14:55:32] ERROR: invalid port value ':]:9000'
[11-Dec-2014 14:55:32] ERROR: FPM initialization failed
[11-Dec-2014 14:55:32] ERROR: FPM initialization failed
```

I have simply replace the line

```
listen = [::]:9000
```

by

```
listen = 9000
```

It works for me.
