### PR TITLE
Remove Indexes option from /var/www

### DIFF
--- a/5.4/apache/apache2.conf
+++ b/5.4/apache/apache2.conf
@@ -31,7 +31,6 @@ Listen 80
 </Directory>
 
 <Directory /var/www/>
-	Options Indexes FollowSymLinks
 	AllowOverride All
 	Require all granted
 </Directory>

--- a/5.5/apache/apache2.conf
+++ b/5.5/apache/apache2.conf
@@ -31,7 +31,6 @@ Listen 80
 </Directory>
 
 <Directory /var/www/>
-	Options Indexes FollowSymLinks
 	AllowOverride All
 	Require all granted
 </Directory>

--- a/5.6/apache/apache2.conf
+++ b/5.6/apache/apache2.conf
@@ -31,7 +31,6 @@ Listen 80
 </Directory>
 
 <Directory /var/www/>
-	Options Indexes FollowSymLinks
 	AllowOverride All
 	Require all granted
 </Directory>


### PR DESCRIPTION
Fixes https://github.com/docker-library/wordpress/issues/33