### PR TITLE
Tell apt-get to actually autoremove everything it should

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -48,7 +48,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -61,7 +61,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -49,7 +49,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -48,7 +48,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -61,7 +61,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -49,7 +49,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -48,7 +48,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -61,7 +61,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -49,7 +49,7 @@ RUN buildDeps=" \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove $buildDeps \
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
 	&& make clean
 
 COPY docker-php-ext-* /usr/local/bin/


### PR DESCRIPTION
I just discovered today that `autoremove` doesn't remove packages that are required *or* suggested by any installed package, even if the package that auto-installed them gets removed.

I ended up adding `-o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false` in jwilder/docker-gen#66 to get `apt-get` to remove additional packages that it wasn't removing otherwise.

I'm sure there are other images where this change would make sense, but I thought I'd start with `php`.