### PR TITLE
Prevent tar preserving file ownership

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -32,7 +32,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -45,7 +45,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -33,7 +33,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -32,7 +32,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -45,7 +45,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -33,7 +33,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -32,7 +32,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -45,7 +45,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -33,7 +33,7 @@ RUN buildDeps=" \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
 	&& mkdir -p /usr/src/php \
-	&& tar -xf php.tar.bz2 -C /usr/src/php --strip-components=1 \
+	&& tar -xof php.tar.bz2 -C /usr/src/php --strip-components=1 \
 	&& rm php.tar.bz2* \
 	&& cd /usr/src/php \
 	&& ./configure \


### PR DESCRIPTION
This change prevents tar from preserving file ownership metadata when it extracts the PHP source archives. This allows containers based on these images to be installed on Circle CI build containers which are LXC containers with restricted UID ranges.