### PR TITLE
Rename config0.m4 to config.m4 to avoid phpize failure

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -21,7 +21,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -42,7 +45,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -34,7 +34,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -55,7 +58,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -22,7 +22,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -43,7 +46,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -21,7 +21,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -42,7 +45,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -34,7 +34,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -55,7 +58,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -22,7 +22,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -43,7 +46,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -21,7 +21,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -42,7 +45,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -34,7 +34,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -55,7 +58,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 # persistent / runtime deps
-RUN apt-get update && apt-get install -y ca-certificates curl libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y ca-certificates curl libpcre3 librecode0 libsqlite3-0 libxml2 --no-install-recommends && rm -r /var/lib/apt/lists/*
 
 # phpize deps
 RUN apt-get update && apt-get install -y autoconf file gcc libc-dev make pkg-config re2c --no-install-recommends && rm -r /var/lib/apt/lists/*
@@ -22,7 +22,10 @@ RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
 		libcurl4-openssl-dev \
+		libpcre3-dev \
 		libreadline6-dev \
+		librecode-dev \
+		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
 	" \
@@ -43,7 +46,9 @@ RUN buildDeps=" \
 		--enable-mysqlnd \
 		--with-curl \
 		--with-openssl \
+		--with-pcre \
 		--with-readline \
+		--with-recode \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \


### PR DESCRIPTION
phpize in docker-php-ext-install would fail if it cannot find config.m4. Some modules, such as zlib, sqlite3 use the name cnofig0.m4 instead of config.m4. This commit performs auto renaming after php is installed.