### PR TITLE
Remove file from buildDeps

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -20,7 +20,6 @@ ENV PHP_VERSION 5.4.39
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -33,7 +33,6 @@ ENV PHP_VERSION 5.4.39
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -21,7 +21,6 @@ ENV PHP_VERSION 5.4.39
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -20,7 +20,6 @@ ENV PHP_VERSION 5.5.23
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -33,7 +33,6 @@ ENV PHP_VERSION 5.5.23
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -21,7 +21,6 @@ ENV PHP_VERSION 5.5.23
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -20,7 +20,6 @@ ENV PHP_VERSION 5.6.7
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -33,7 +33,6 @@ ENV PHP_VERSION 5.6.7
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -21,7 +21,6 @@ ENV PHP_VERSION 5.6.7
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
 		bzip2 \
-		file \
 		libcurl4-openssl-dev \
 		libreadline6-dev \
 		libssl-dev \


### PR DESCRIPTION
file is still needed for docker-php-install-ext.