### PR TITLE
Tells FPM not to clear the environment in workers

### DIFF
--- a/5.4/fpm/php-fpm.conf
+++ b/5.4/fpm/php-fpm.conf
@@ -21,3 +21,5 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+
+clear_env = no

--- a/5.5/fpm/php-fpm.conf
+++ b/5.5/fpm/php-fpm.conf
@@ -21,3 +21,5 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+
+clear_env = no

--- a/5.6/fpm/php-fpm.conf
+++ b/5.6/fpm/php-fpm.conf
@@ -21,3 +21,5 @@ pm.max_children = 5
 pm.start_servers = 2
 pm.min_spare_servers = 1
 pm.max_spare_servers = 3
+
+clear_env = no


### PR DESCRIPTION
Allows php scripts executed with FPM to access env vars such as env vars
from linked containers

see #74