### PR TITLE
Reduced the size of the image by about %23

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -23,7 +23,6 @@ ENV PHP_VERSION 5.4.40
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -33,7 +32,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -55,9 +54,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -36,7 +36,6 @@ ENV PHP_VERSION 5.4.40
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -46,7 +45,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -68,9 +67,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.4/apache/docker-php-ext-configure
+++ b/5.4/apache/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.4/apache/docker-php-ext-install
+++ b/5.4/apache/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.4/docker-php-ext-configure
+++ b/5.4/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.4/docker-php-ext-install
+++ b/5.4/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -24,7 +24,6 @@ ENV PHP_VERSION 5.4.40
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -34,7 +33,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -56,9 +55,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.4/fpm/docker-php-ext-configure
+++ b/5.4/fpm/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.4/fpm/docker-php-ext-install
+++ b/5.4/fpm/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -23,7 +23,6 @@ ENV PHP_VERSION 5.5.24
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -33,7 +32,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -55,9 +54,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -36,7 +36,6 @@ ENV PHP_VERSION 5.5.24
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -46,7 +45,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -68,9 +67,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.5/apache/docker-php-ext-configure
+++ b/5.5/apache/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.5/apache/docker-php-ext-install
+++ b/5.5/apache/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.5/docker-php-ext-configure
+++ b/5.5/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.5/docker-php-ext-install
+++ b/5.5/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -24,7 +24,6 @@ ENV PHP_VERSION 5.5.24
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -34,7 +33,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -56,9 +55,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.5/fpm/docker-php-ext-configure
+++ b/5.5/fpm/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.5/fpm/docker-php-ext-install
+++ b/5.5/fpm/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -23,7 +23,6 @@ ENV PHP_VERSION 5.6.8
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -33,7 +32,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -55,9 +54,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -36,7 +36,6 @@ ENV PHP_VERSION 5.6.8
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -46,7 +45,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -68,9 +67,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.6/apache/docker-php-ext-configure
+++ b/5.6/apache/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.6/apache/docker-php-ext-install
+++ b/5.6/apache/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.6/docker-php-ext-configure
+++ b/5.6/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.6/docker-php-ext-install
+++ b/5.6/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -24,7 +24,6 @@ ENV PHP_VERSION 5.6.8
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
-		bzip2 \
 		libcurl4-openssl-dev \
 		libpcre3-dev \
 		libreadline6-dev \
@@ -34,7 +33,7 @@ RUN buildDeps=" \
 		libxml2-dev \
 	" \
 	&& set -x \
-	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+	&& apt-get update && apt-get install -y bzip2 $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2/from/this/mirror" -o php.tar.bz2 \
 	&& curl -SL "http://php.net/get/php-$PHP_VERSION.tar.bz2.asc/from/this/mirror" -o php.tar.bz2.asc \
 	&& gpg --verify php.tar.bz2.asc \
@@ -56,9 +55,11 @@ RUN buildDeps=" \
 		--with-zlib \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& make clean \
+	&& tar -C /usr/src -cj -f /usr/src/php.tar.bz2 php \
+	&& rm -rf /usr/src/php \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
-	&& make clean
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/5.6/fpm/docker-php-ext-configure
+++ b/5.6/fpm/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/5.6/fpm/docker-php-ext-install
+++ b/5.6/fpm/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 ext="$1"
 extDir="/usr/src/php/ext/$ext"
 if [ -z "$ext" -o ! -d "$extDir" ]; then

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+[ -d /usr/src/php ] || tar -C /usr/src -xj -f /usr/src/php.tar.bz2
+
 cd /usr/src/php/ext
 
 usage() {
@@ -58,3 +60,5 @@ for ext in "${exts[@]}"; do
 		make clean
 	)
 done
+
+rm -rf /usr/src/php


### PR DESCRIPTION
It bzips the /usr/src/php to reduce the size of the image. bzip2
package is moved outsize of the $buildDeps just for backwards
compatibility otherwise one would have needed to add bzip2 into
their Dockerfile as build dependency.