### PR TITLE
remove prefix as it is not correct.

### DIFF
--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -41,7 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+		ini="/usr/local/etc/php/conf.d/ext-$ext.ini"
 		for module in modules/*.so; do
 			if [ -f "$module" ]; then
 				if grep -q zend_extension_entry "$module"; then


### PR DESCRIPTION
when installing plugin this is the error: e.g.
`grep: /usr/local/etc/php/conf.d/docker-php-ext-zip.ini: No such file or directory` but the correct path is `grep: /usr/local/etc/php/conf.d/ext-zip.ini: No such file or directory` see https://github.com/docker-library/php/issues/106