### PR TITLE
Update to 5.4.43, 5.5.27, and 5.6.11

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.4.42
+ENV PHP_VERSION 5.4.43
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.4/apache/Dockerfile
+++ b/5.4/apache/Dockerfile
@@ -31,7 +31,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.4.42
+ENV PHP_VERSION 5.4.43
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.4/fpm/Dockerfile
+++ b/5.4/fpm/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.4.42
+ENV PHP_VERSION 5.4.43
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.5.26
+ENV PHP_VERSION 5.5.27
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -31,7 +31,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.5.26
+ENV PHP_VERSION 5.5.27
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.5.26
+ENV PHP_VERSION 5.5.27
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.6.10
+ENV PHP_VERSION 5.6.11
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -31,7 +31,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.6.10
+ENV PHP_VERSION 5.6.11
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe \
 		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 	done
 
-ENV PHP_VERSION 5.6.10
+ENV PHP_VERSION 5.6.11
 
 # --enable-mysqlnd is included below because it's harder to compile after the fact the extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN buildDeps=" \


### PR DESCRIPTION
As announced here;

PHP 5.4.43 http://php.net/archive/2015.php#id2015-07-09-1
PHP 5.5.27 http://php.net/archive/2015.php#id2015-07-10-2
PHP 5.6.11 http://php.net/archive/2015.php#id2015-07-10-3

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>