### PR TITLE
Add new "docker-php-ext-enable" script for more intelligent module enabling

### DIFF
--- a/5.4/apache/docker-php-ext-enable
+++ b/5.4/apache/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.4/apache/docker-php-ext-install
+++ b/5.4/apache/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.4/docker-php-ext-enable
+++ b/5.4/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.4/docker-php-ext-install
+++ b/5.4/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.4/fpm/docker-php-ext-enable
+++ b/5.4/fpm/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.4/fpm/docker-php-ext-install
+++ b/5.4/fpm/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.5/apache/docker-php-ext-enable
+++ b/5.5/apache/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.5/apache/docker-php-ext-install
+++ b/5.5/apache/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.5/docker-php-ext-enable
+++ b/5.5/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.5/docker-php-ext-install
+++ b/5.5/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.5/fpm/docker-php-ext-enable
+++ b/5.5/fpm/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.5/fpm/docker-php-ext-install
+++ b/5.5/fpm/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.6/apache/docker-php-ext-enable
+++ b/5.6/apache/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.6/apache/docker-php-ext-install
+++ b/5.6/apache/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.6/docker-php-ext-enable
+++ b/5.6/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.6/docker-php-ext-install
+++ b/5.6/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/5.6/fpm/docker-php-ext-enable
+++ b/5.6/fpm/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/5.6/fpm/docker-php-ext-install
+++ b/5.6/fpm/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/7.0/apache/docker-php-ext-enable
+++ b/7.0/apache/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/7.0/apache/docker-php-ext-install
+++ b/7.0/apache/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/7.0/docker-php-ext-enable
+++ b/7.0/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/7.0/docker-php-ext-install
+++ b/7.0/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/7.0/fpm/docker-php-ext-enable
+++ b/7.0/fpm/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/7.0/fpm/docker-php-ext-install
+++ b/7.0/fpm/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -e
+
+cd "$(php -r 'echo ini_get("extension_dir");')"
+
+usage() {
+	echo "usage: $0 module-name [module-name ...]"
+	echo "   ie: $0 gd mysqli"
+	echo "       $0 pdo pdo_mysql"
+	echo
+	echo 'Possible values for module-name:'
+	echo $(find -maxdepth 1 -type f -name '*.so' -exec basename '{}' ';' | sort)
+}
+
+modules=()
+while [ $# -gt 0 ]; do
+	module="$1"
+	shift
+	if [ -z "$module" ]; then
+		continue
+	fi
+	if [ -f "$module.so" -a ! -f "$module" ]; then
+		# allow ".so" to be optional
+		module+='.so'
+	fi
+	if [ ! -f "$module" ]; then
+		echo >&2 "error: $(readlink -f "$module") does not exist"
+		echo >&2
+		usage >&2
+		exit 1
+	fi
+	modules+=( "$module" )
+done
+
+if [ "${#modules[@]}" -eq 0 ]; then
+	usage >&2
+	exit 1
+fi
+
+for module in "${modules[@]}"; do
+	if grep -q zend_extension_entry "$module"; then
+		# https://wiki.php.net/internals/extensions#loading_zend_extensions
+		line="zend_extension=$module"
+	else
+		line="extension=$module"
+	fi
+
+	ext="$(basename "$module")"
+	ext="${ext%.*}"
+	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+		# this isn't perfect, but it's better than nothing
+		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
+		echo >&2
+		echo >&2 "warning: $ext ($module) is already loaded!"
+		echo >&2
+		continue
+	fi
+
+	ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
+	if ! grep -q "$line" "$ini" 2>/dev/null; then
+		echo "$line" >> "$ini"
+	fi
+done

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -41,20 +41,7 @@ for ext in "${exts[@]}"; do
 		[ -e Makefile ] || docker-php-ext-configure "$ext"
 		make
 		make install
-		ini="/usr/local/etc/php/conf.d/docker-php-ext-$ext.ini"
-		for module in modules/*.so; do
-			if [ -f "$module" ]; then
-				if grep -q zend_extension_entry "$module"; then
-					# https://wiki.php.net/internals/extensions#loading_zend_extensions
-					line="zend_extension=$(basename "$module")"
-				else
-					line="extension=$(basename "$module")"
-				fi
-				if ! grep -q "$line" "$ini" 2>/dev/null; then
-					echo "$line" >> "$ini"
-				fi
-			fi
-		done
+		find modules -maxdepth 1 -name '*.so' -exec basename '{}' ';' | xargs --no-run-if-empty --verbose docker-php-ext-enable
 		make clean
 	)
 done


### PR DESCRIPTION
This also updates `docker-php-ext-install` to invoke this script properly after successful extension compilation.

If modules are determined to already be enabled, it'll skip them appropriately.

This removes simple warnings like `PHP Warning:  Module 'curl' already loaded in Unknown on line 0`, and enables things like `pecl install mongo && docker-php-ext-enable mongo`.

Fixes https://github.com/docker-library/php/issues/102
Fixes https://github.com/docker-library/drupal/pull/5