### PR TITLE
install build time deps from docker-php-ext-install for alpine

### DIFF
--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -37,8 +26,11 @@ ENV PHP_VERSION 5.5.35
 ENV PHP_FILENAME php-5.5.35.tar.xz
 ENV PHP_SHA256 9bef96634af853960be085690b2f4cea5850b749ea950942769b22b1a9f24873
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/5.5/alpine/docker-php-ext-install
+++ b/5.5/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.5/apache/docker-php-ext-install
+++ b/5.5/apache/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.5/docker-php-ext-install
+++ b/5.5/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.5/fpm/alpine/Dockerfile
+++ b/5.5/fpm/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -38,8 +27,11 @@ ENV PHP_VERSION 5.5.35
 ENV PHP_FILENAME php-5.5.35.tar.xz
 ENV PHP_SHA256 9bef96634af853960be085690b2f4cea5850b749ea950942769b22b1a9f24873
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/5.5/fpm/alpine/docker-php-ext-install
+++ b/5.5/fpm/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.5/fpm/docker-php-ext-install
+++ b/5.5/fpm/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.5/zts/alpine/Dockerfile
+++ b/5.5/zts/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -38,8 +27,11 @@ ENV PHP_VERSION 5.5.35
 ENV PHP_FILENAME php-5.5.35.tar.xz
 ENV PHP_SHA256 9bef96634af853960be085690b2f4cea5850b749ea950942769b22b1a9f24873
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/5.5/zts/alpine/docker-php-ext-install
+++ b/5.5/zts/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.5/zts/docker-php-ext-install
+++ b/5.5/zts/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -37,8 +26,11 @@ ENV PHP_VERSION 5.6.21
 ENV PHP_FILENAME php-5.6.21.tar.xz
 ENV PHP_SHA256 566ff1a486cb0485ed477a91ea292423f77a58671270ff73b74e67e3ce7084f9
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/5.6/alpine/docker-php-ext-install
+++ b/5.6/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/apache/docker-php-ext-install
+++ b/5.6/apache/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/docker-php-ext-install
+++ b/5.6/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -38,8 +27,11 @@ ENV PHP_VERSION 5.6.21
 ENV PHP_FILENAME php-5.6.21.tar.xz
 ENV PHP_SHA256 566ff1a486cb0485ed477a91ea292423f77a58671270ff73b74e67e3ce7084f9
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/5.6/fpm/alpine/docker-php-ext-install
+++ b/5.6/fpm/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/fpm/docker-php-ext-install
+++ b/5.6/fpm/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -38,8 +27,11 @@ ENV PHP_VERSION 5.6.21
 ENV PHP_FILENAME php-5.6.21.tar.xz
 ENV PHP_SHA256 566ff1a486cb0485ed477a91ea292423f77a58671270ff73b74e67e3ce7084f9
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/5.6/zts/alpine/docker-php-ext-install
+++ b/5.6/zts/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/5.6/zts/docker-php-ext-install
+++ b/5.6/zts/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -37,8 +26,11 @@ ENV PHP_VERSION 7.0.6
 ENV PHP_FILENAME php-7.0.6.tar.xz
 ENV PHP_SHA256 1b237a9455e5476a425dbb9d99966bad68107747c601958cb9558a7fb49ab419
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/7.0/alpine/docker-php-ext-install
+++ b/7.0/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/apache/docker-php-ext-install
+++ b/7.0/apache/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/docker-php-ext-install
+++ b/7.0/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -38,8 +27,11 @@ ENV PHP_VERSION 7.0.6
 ENV PHP_FILENAME php-7.0.6.tar.xz
 ENV PHP_SHA256 1b237a9455e5476a425dbb9d99966bad68107747c601958cb9558a7fb49ab419
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/7.0/fpm/alpine/docker-php-ext-install
+++ b/7.0/fpm/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/fpm/docker-php-ext-install
+++ b/7.0/fpm/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -38,8 +27,11 @@ ENV PHP_VERSION 7.0.6
 ENV PHP_FILENAME php-7.0.6.tar.xz
 ENV PHP_SHA256 1b237a9455e5476a425dbb9d99966bad68107747c601958cb9558a7fb49ab419
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/7.0/zts/alpine/docker-php-ext-install
+++ b/7.0/zts/alpine/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/7.0/zts/docker-php-ext-install
+++ b/7.0/zts/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,16 +1,5 @@
 FROM alpine:3.3
 
-# phpize deps
-RUN apk add --no-cache --virtual .phpize-deps \
-		autoconf \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkgconf \
-		re2c
-
 # persistent / runtime deps
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -37,8 +26,11 @@ ENV PHP_VERSION %%PHP_VERSION%%
 ENV PHP_FILENAME %%PHP_FILENAME%%
 ENV PHP_SHA256 %%PHP_SHA256%%
 
+ENV PHPIZE_DEPS autoconf file g++ gcc libc-dev make pkgconf re2c
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
+		$PHPIZE_DEPS \
 		curl-dev \
 		gnupg \
 		libedit-dev \

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -55,6 +55,11 @@ if [ -z "$exts" ]; then
 	exit 1
 fi
 
+: ${PHPIZE_DEPS:="autoconf file g++ gcc libc-dev make pkgconf re2c"}
+if [ -e /lib/apk/db/installed ]; then
+	apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+fi
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -69,3 +74,7 @@ for ext in $exts; do
 		make -j"$j" clean
 	)
 done
+
+if [ -e /lib/apk/db/installed ]; then
+	apk del .phpize-deps
+fi


### PR DESCRIPTION
We don't need the build dependencies during runtime, so we temporarily
install them when building extension. This reduces image size with 50%.