### PR TITLE
Explicitly enable "mbstring" by default (since certain pecl bits cannot work properly otherwise)

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -64,6 +64,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -66,6 +66,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.5/apache/Dockerfile
+++ b/5.5/apache/Dockerfile
@@ -77,6 +77,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.5/fpm/Dockerfile
+++ b/5.5/fpm/Dockerfile
@@ -65,6 +65,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.5/fpm/alpine/Dockerfile
+++ b/5.5/fpm/alpine/Dockerfile
@@ -67,6 +67,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.5/zts/Dockerfile
+++ b/5.5/zts/Dockerfile
@@ -65,6 +65,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.5/zts/alpine/Dockerfile
+++ b/5.5/zts/alpine/Dockerfile
@@ -67,6 +67,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -64,6 +64,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -66,6 +66,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -77,6 +77,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -65,6 +65,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -67,6 +67,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/zts/Dockerfile
+++ b/5.6/zts/Dockerfile
@@ -65,6 +65,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -67,6 +67,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -64,6 +64,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -66,6 +66,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -77,6 +77,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -65,6 +65,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -67,6 +67,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/zts/Dockerfile
+++ b/7.0/zts/Dockerfile
@@ -65,6 +65,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -67,6 +67,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -66,6 +66,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -64,6 +64,8 @@ RUN set -xe \
 		--disable-cgi \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+		--enable-mbstring \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \


### PR DESCRIPTION
Fixes #34
Fixes #195