### PR TITLE
Avoid cache in Alpine apk add

### DIFF
--- a/5.5/alpine/Dockerfile
+++ b/5.5/alpine/Dockerfile
@@ -83,7 +83,7 @@ RUN set -xe \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \
-	&& apk add --virtual .php-rundeps $runDeps \
+	&& apk add --no-cache --virtual .php-rundeps $runDeps \
 	&& apk del .build-deps
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -83,7 +83,7 @@ RUN set -xe \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \
-	&& apk add --virtual .php-rundeps $runDeps \
+	&& apk add --no-cache --virtual .php-rundeps $runDeps \
 	&& apk del .build-deps
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -83,7 +83,7 @@ RUN set -xe \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \
-	&& apk add --virtual .php-rundeps $runDeps \
+	&& apk add --no-cache --virtual .php-rundeps $runDeps \
 	&& apk del .build-deps
 
 COPY docker-php-ext-* /usr/local/bin/

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -83,7 +83,7 @@ RUN set -xe \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \
-	&& apk add --virtual .php-rundeps $runDeps \
+	&& apk add --no-cache --virtual .php-rundeps $runDeps \
 	&& apk del .build-deps
 
 COPY docker-php-ext-* /usr/local/bin/


### PR DESCRIPTION
Adds `--no-cache` to the final `apk add` in the `Dockerfile`. The other `apk add`'s already have this flag; however the cache is currently created anyway because of the final `apk add`.