### PR TITLE
Remove php src the right way for lightweight containers.

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -35,6 +35,8 @@ ENV PHP_VERSION %%PHP_VERSION%%
 ENV PHP_FILENAME %%PHP_FILENAME%%
 ENV PHP_SHA256 %%PHP_SHA256%%
 
+COPY docker-php-source /usr/local/bin/
+
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -53,10 +55,7 @@ RUN set -xe \
 	done \
 	&& gpg --batch --verify "$PHP_FILENAME.asc" "$PHP_FILENAME" \
 	&& rm -r "$GNUPGHOME" "$PHP_FILENAME.asc" \
-	&& mkdir -p /usr/src \
-	&& tar -Jxf "$PHP_FILENAME" -C /usr/src \
-	&& mv "/usr/src/php-$PHP_VERSION" /usr/src/php \
-	&& rm "$PHP_FILENAME" \
+	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \
 		--with-config-file-path="$PHP_INI_DIR" \
@@ -83,7 +82,8 @@ RUN set -xe \
 			| sort -u \
 	)" \
 	&& apk add --no-cache --virtual .php-rundeps $runDeps \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	&& docker-php-source delete
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -31,6 +31,8 @@ ENV PHP_VERSION %%PHP_VERSION%%
 ENV PHP_FILENAME %%PHP_FILENAME%%
 ENV PHP_SHA256 %%PHP_SHA256%%
 
+COPY docker-php-source /usr/local/bin/
+
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
@@ -51,9 +53,7 @@ RUN set -xe \
 	done \
 	&& gpg --batch --verify "$PHP_FILENAME.asc" "$PHP_FILENAME" \
 	&& rm -r "$GNUPGHOME" "$PHP_FILENAME.asc" \
-	&& mkdir -p /usr/src/php \
-	&& tar -xf "$PHP_FILENAME" -C /usr/src/php --strip-components=1 \
-	&& rm "$PHP_FILENAME" \
+	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \
 		--with-config-file-path="$PHP_INI_DIR" \
@@ -72,7 +72,8 @@ RUN set -xe \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; } \
 	&& make clean \
-	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
+	&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps \
+	&& docker-php-source delete
 
 COPY docker-php-ext-* /usr/local/bin/
 

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -28,6 +28,8 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+docker-php-source extract
+
 set -x
 cd "$extDir"
 phpize

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -2,13 +2,12 @@
 set -e
 
 ext="$1"
-extDir="/usr/src/php/ext/$ext"
-if [ -z "$ext" ] || ! [ -d "$extDir" ]; then
+if [ -z "$ext" ] || ! [ $(grep -c " $ext " /available-exts) -eq 1 ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo >&2 $(find /usr/src/php/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)
+	echo $(cat /available-exts)
 	exit 1
 fi
 shift
@@ -31,6 +30,6 @@ fi
 docker-php-source extract
 
 set -x
-cd "$extDir"
+cd "/usr/src/php/ext/$ext"
 phpize
 ./configure "$@"

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
-
-cd /usr/src/php/ext
+PHP_SRC_DIR=/usr/src/php
 
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
@@ -12,7 +11,7 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(find /usr/src/php/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)
+	echo $(cat /available-exts)
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -41,8 +40,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if [ ! -d "$ext" ]; then
-		echo >&2 "error: $(pwd -P)/$ext does not exist"
+    if [ ! $(grep -c " $ext " /available-exts) -eq 1 ]; then
+		echo >&2 "error: $PHP_SRC_DIR/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -73,6 +72,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 docker-php-source extract
+cd $PHP_SRC_DIR/ext
 
 for ext in $exts; do
 	(

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -72,6 +72,8 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+docker-php-source extract
+
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -90,3 +92,4 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
+docker-php-source delete

--- a/docker-php-source
+++ b/docker-php-source
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+SRC_DIR=/usr/src
+PHP_SRC_DIR=$SRC_DIR/php
+
+usage() {
+    echo "usage: $0 COMMAND"
+    echo
+    echo "Manage php source tarball lifecycle."
+    echo
+    echo "Commands:"
+    echo "   extract  extract php source tarball into directory $PHP_SRC_DIR if not already done."
+    echo "   delete   delete extracted php source located into $PHP_SRC_DIR if not already done."
+    echo
+}
+
+case "$1" in
+    extract)
+        if [ -f "$PHP_SRC_DIR" ] ; then
+            echo "php source tarball already extracted, skipping extract step."
+        else
+            mkdir -p $SRC_DIR
+            tar -Jxf "/$PHP_FILENAME" -C $SRC_DIR
+            mv "$PHP_SRC_DIR-$PHP_VERSION" $PHP_SRC_DIR
+            echo "php source tarball successfully extracted."
+        fi
+        ;;
+    delete)
+        if [ -d "$PHP_SRC_DIR" ] ; then
+            rm -rf $PHP_SRC_DIR \
+            && echo "php extracted source successfully deleted."
+        else
+            echo "php extracted source already deleted, skipping delete extracted source step."
+        fi
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/docker-php-source
+++ b/docker-php-source
@@ -22,6 +22,7 @@ case "$1" in
             mkdir -p $SRC_DIR
             tar -Jxf "/$PHP_FILENAME" -C $SRC_DIR
             mv "$PHP_SRC_DIR-$PHP_VERSION" $PHP_SRC_DIR
+            echo " "$(find $PHP_SRC_DIR/ext -mindepth 2 -maxdepth 2 -type f -name 'config.m4' | cut -d/ -f6 | sort)" " > /available-exts
             echo "php source tarball successfully extracted."
         fi
         ;;

--- a/update.sh
+++ b/update.sh
@@ -68,11 +68,13 @@ for version in "${versions[@]}"; do
 	
 	cp -v Dockerfile-debian.template "$version/Dockerfile"
 	cp -v docker-php-ext-* "$version/"
+	cp -v docker-php-source "$version/"
 	dockerfiles+=( "$version/Dockerfile" )
 	
 	if [ -d "$version/alpine" ]; then
 		cp -v Dockerfile-alpine.template "$version/alpine/Dockerfile"
 		cp -v docker-php-ext-* "$version/alpine/"
+		cp -v docker-php-source "$version/alpine/"
 		dockerfiles+=( "$version/alpine/Dockerfile" )
 	fi
 	
@@ -98,6 +100,7 @@ for version in "${versions[@]}"; do
 			ia && ac == 1 { system("cat '$variant'-Dockerfile-block-" ab) }
 		' "$base" > "$version/$target/Dockerfile"
 		cp -v docker-php-ext-* "$version/$target/"
+		cp -v docker-php-source "$version/$target/"
 		dockerfiles+=( "$version/$target/Dockerfile" )
 	done
 	


### PR DESCRIPTION
Fixes #234.

- I will call `update.sh` after the proposed patch have been reviewed.
- I've also included some kind of debian support.

According to @yosifkit https://github.com/docker-library/php/issues/234#issuecomment-222853089 we should obtain that kind of result (uncompressed size container images):
```
REPOSITORY          TAG                IMAGE ID            CREATED             VIRTUAL SIZE
# current size
php                 alpine             bdae0b0de098        3 days ago          191.5 MB

# sans all source
<none>              <none>             537592e5c872        53 seconds ago      44.3 MB

# keep the php src xz
<none>              <none>             cb1f5c08b4f9        50 minutes ago      55.79 MB
```