### PR TITLE
Change uid of www-data user before starting apache

### DIFF
--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -2,4 +2,5 @@ COPY apache2-foreground /usr/local/bin/
 WORKDIR /var/www/html
 
 EXPOSE 80
-CMD ["apache2-foreground"]
+ENTRYPOINT [ "sh", "-c", "usermod --non-unique --uid ${RUN_AS_UID:-33} www-data && chown -R www-data /run/apache2 /run/lock/apache2 /var/cache/apache2/mod_cache_disk /var/log/apache2 && exec apache2-foreground" ]
+

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -6,4 +6,7 @@ COPY apache2-foreground /usr/local/bin/
 WORKDIR /var/www/html
 
 EXPOSE 80
-ENTRYPOINT ["/docker-entrypoint.sh", "apache2-foreground"]
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]
+
+CMD [ "apache2-foreground" ]

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -1,6 +1,9 @@
+
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+
 COPY apache2-foreground /usr/local/bin/
 WORKDIR /var/www/html
 
 EXPOSE 80
-ENTRYPOINT [ "sh", "-c", "usermod --non-unique --uid ${RUN_AS_UID:-33} www-data && chown -R www-data /run/apache2 /run/lock/apache2 /var/cache/apache2/mod_cache_disk /var/log/apache2 && exec apache2-foreground" ]
-
+ENTRYPOINT ["/docker-entrypoint.sh", "apache2-foreground"]

--- a/docker-entrypoint.d/00-update-uid
+++ b/docker-entrypoint.d/00-update-uid
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# current www-data UID
+CURRENT_UID=`id -u www-data`
+WANTED_UID=${RUN_AS_UID:-33}
+
+# check if UID need to be updated
+if [ $CURRENT_UID -ne $WANTED_UID ]; then
+    echo "Updating www-data UID to $WANTED_UID"
+    usermod --non-unique --uid $WANTED_UID www-data
+    chown -R www-data /run/apache2 /run/lock/apache2 /var/cache/apache2/mod_cache_disk /var/log/apache2
+fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DIR=/docker-entrypoint.d
+
+if [[ -d "$DIR" ]]
+then
+  /bin/run-parts --verbose "$DIR"
+fi
+
+exec "$@"

--- a/update.sh
+++ b/update.sh
@@ -110,6 +110,9 @@ for version in "${versions[@]}"; do
 			ia { ac++ }
 			ia && ac == 1 { system("cat '$variant'-Dockerfile-block-" ab) }
 		' "$base" > "$version/$target/Dockerfile"
+		if [ $target == "apache" ]; then
+		    cp -vr docker-entrypoint.sh docker-entrypoint.d "$version/$target/"
+		fi
 		cp -v docker-php-ext-* "$version/$target/"
 		cp -v docker-php-source "$version/$target/"
 		dockerfiles+=( "$version/$target/Dockerfile" )


### PR DESCRIPTION
This PR is a proposal to fix https://github.com/docker-library/php/issues/14 with use of `usermod` command.

This PR replace entrypoint with 3 commands :
- `usermod` on www-data to change uid with value of RUN_AS_UID env variable
- `chown` on directory previously owned by www-data
- finally run standard apache entrypoint : `apache2-foreground`
