### PR TITLE
enable ftp by default

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -73,6 +73,8 @@ RUN set -xe \
 		--enable-mysqlnd \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
 		--enable-mbstring \
+# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+		--enable-ftp \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -66,6 +66,8 @@ RUN set -xe \
 		--enable-mysqlnd \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
 		--enable-mbstring \
+# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+		--enable-ftp \
 		--with-curl \
 		--with-libedit \
 		--with-openssl \


### PR DESCRIPTION
`ftp_ssl_connect()` needs ftp to be built statically into PHP #236 

