### PR TITLE
Return backwards compatibility to the way we handle /usr/src/php/ext/* (especially for user-supplied subdirectories looking to utilize docker-php-ext-* for non-core modules)

### DIFF
--- a/5.5/alpine/docker-php-ext-configure
+++ b/5.5/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/alpine/docker-php-ext-install
+++ b/5.5/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/alpine/docker-php-source
+++ b/5.5/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.5/apache/docker-php-ext-configure
+++ b/5.5/apache/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/apache/docker-php-ext-install
+++ b/5.5/apache/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/apache/docker-php-source
+++ b/5.5/apache/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.5/docker-php-ext-configure
+++ b/5.5/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/docker-php-ext-install
+++ b/5.5/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/docker-php-source
+++ b/5.5/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.5/fpm/alpine/docker-php-ext-configure
+++ b/5.5/fpm/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/fpm/alpine/docker-php-ext-install
+++ b/5.5/fpm/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/fpm/alpine/docker-php-source
+++ b/5.5/fpm/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.5/fpm/docker-php-ext-configure
+++ b/5.5/fpm/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/fpm/docker-php-ext-install
+++ b/5.5/fpm/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/fpm/docker-php-source
+++ b/5.5/fpm/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.5/zts/alpine/docker-php-ext-configure
+++ b/5.5/zts/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/zts/alpine/docker-php-ext-install
+++ b/5.5/zts/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/zts/alpine/docker-php-source
+++ b/5.5/zts/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.5/zts/docker-php-ext-configure
+++ b/5.5/zts/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.5/zts/docker-php-ext-install
+++ b/5.5/zts/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.5/zts/docker-php-source
+++ b/5.5/zts/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/alpine/docker-php-ext-configure
+++ b/5.6/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/alpine/docker-php-ext-install
+++ b/5.6/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/alpine/docker-php-source
+++ b/5.6/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/apache/docker-php-ext-configure
+++ b/5.6/apache/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/apache/docker-php-ext-install
+++ b/5.6/apache/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/apache/docker-php-source
+++ b/5.6/apache/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/docker-php-ext-configure
+++ b/5.6/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/docker-php-ext-install
+++ b/5.6/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/docker-php-source
+++ b/5.6/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/fpm/alpine/docker-php-ext-configure
+++ b/5.6/fpm/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/fpm/alpine/docker-php-ext-install
+++ b/5.6/fpm/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/fpm/alpine/docker-php-source
+++ b/5.6/fpm/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/fpm/docker-php-ext-configure
+++ b/5.6/fpm/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/fpm/docker-php-ext-install
+++ b/5.6/fpm/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/fpm/docker-php-source
+++ b/5.6/fpm/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/zts/alpine/docker-php-ext-configure
+++ b/5.6/zts/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/zts/alpine/docker-php-ext-install
+++ b/5.6/zts/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/zts/alpine/docker-php-source
+++ b/5.6/zts/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/5.6/zts/docker-php-ext-configure
+++ b/5.6/zts/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/5.6/zts/docker-php-ext-install
+++ b/5.6/zts/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/5.6/zts/docker-php-source
+++ b/5.6/zts/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/alpine/docker-php-ext-configure
+++ b/7.0/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/alpine/docker-php-ext-install
+++ b/7.0/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/alpine/docker-php-source
+++ b/7.0/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/apache/docker-php-ext-configure
+++ b/7.0/apache/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/apache/docker-php-ext-install
+++ b/7.0/apache/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/apache/docker-php-source
+++ b/7.0/apache/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/docker-php-ext-configure
+++ b/7.0/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/docker-php-ext-install
+++ b/7.0/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/docker-php-source
+++ b/7.0/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/fpm/alpine/docker-php-ext-configure
+++ b/7.0/fpm/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/fpm/alpine/docker-php-ext-install
+++ b/7.0/fpm/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/fpm/alpine/docker-php-source
+++ b/7.0/fpm/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/fpm/docker-php-ext-configure
+++ b/7.0/fpm/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/fpm/docker-php-ext-install
+++ b/7.0/fpm/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/fpm/docker-php-source
+++ b/7.0/fpm/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/zts/alpine/docker-php-ext-configure
+++ b/7.0/zts/alpine/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/zts/alpine/docker-php-ext-install
+++ b/7.0/zts/alpine/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/zts/alpine/docker-php-source
+++ b/7.0/zts/alpine/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/7.0/zts/docker-php-ext-configure
+++ b/7.0/zts/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/7.0/zts/docker-php-ext-install
+++ b/7.0/zts/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/7.0/zts/docker-php-source
+++ b/7.0/zts/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -1,13 +1,31 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
 ext="$1"
-if [ -z "$ext" ] || ! grep -qE "^$ext$" /usr/src/php-available-exts; then
+extDir="/usr/src/php/ext/$ext"
+if [ -z "$ext" ] || [ ! -d "$extDir" ]; then
 	echo >&2 "usage: $0 ext-name [configure flags]"
 	echo >&2 "   ie: $0 gd --with-jpeg-dir=/usr/local/something"
 	echo >&2
 	echo >&2 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find /usr/src/php/ext \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 	exit 1
 fi
 shift
@@ -27,9 +45,7 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-
 set -x
-cd "/usr/src/php/ext/$ext"
+cd "$extDir"
 phpize
 ./configure "$@"

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -e
 
+srcExists=
+if [ -d /usr/src/php ]; then
+	srcExists=1
+fi
+docker-php-source extract
+if [ -z "$srcExists" ]; then
+	touch /usr/src/php/.docker-delete-me
+fi
+
+cd /usr/src/php/ext
+
 usage() {
 	echo "usage: $0 [-jN] ext-name [ext-name ...]"
 	echo "   ie: $0 gd mysqli"
@@ -10,7 +21,15 @@ usage() {
 	echo 'if custom ./configure arguments are necessary, see docker-php-ext-configure'
 	echo
 	echo 'Possible values for ext-name:'
-	echo $(cat /usr/src/php-available-exts)
+	find . \
+			-mindepth 2 \
+			-maxdepth 2 \
+			-type f \
+			-name 'config.m4' \
+		| xargs -n1 dirname \
+		| xargs -n1 basename \
+		| sort \
+		| xargs
 }
 
 opts="$(getopt -o 'h?j:' --long 'help,jobs:' -- "$@" || { usage >&2 && false; })"
@@ -39,8 +58,8 @@ for ext; do
 	if [ -z "$ext" ]; then
 		continue
 	fi
-	if ! grep -qE "^$ext$" /usr/src/php-available-exts; then
-		echo >&2 "error: /usr/src/php/ext/$ext does not exist"
+	if [ ! -d "$ext" ]; then
+		echo >&2 "error: $PWD/$ext does not exist"
 		echo >&2
 		usage >&2
 		exit 1
@@ -70,9 +89,6 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
-docker-php-source extract
-cd /usr/src/php/ext
-
 for ext in $exts; do
 	(
 		cd "$ext"
@@ -91,4 +107,7 @@ done
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
 	apk del $apkDel
 fi
-docker-php-source delete
+
+if [ -e /usr/src/php/.docker-delete-me ]; then
+	docker-php-source delete
+fi

--- a/docker-php-source
+++ b/docker-php-source
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
+
 dir=/usr/src/php
 
 usage() {
@@ -15,28 +16,17 @@ usage() {
 
 case "$1" in
 	extract)
-		if [ -e "$dir" -a ! -d "$dir" ] ; then
-			echo >&2 "$dir exists and is not a directory"
-			exit 1
-		fi
-		if [ ! -d "$dir" ]; then
-			mkdir -p "$dir"
+		mkdir -p "$dir"
+		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
-
-			if [ ! -f /usr/src/php-available-exts ]; then
-				find "$dir/ext" \
-						-mindepth 2 \
-						-maxdepth 2 \
-						-type f \
-						-name 'config.m4' \
-					| xargs -n1 dirname | xargs -n1 basename | sort \
-				> /usr/src/php-available-exts
-			fi
+			touch "$dir/.docker-extracted"
 		fi
 		;;
+
 	delete)
 		rm -rf "$dir"
 		;;
+
 	*)
 		usage
 		exit 1


### PR DESCRIPTION
Closes #269
Closes #268
Closes #266