### PR TITLE
Remove the comments from being within a command,

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -69,7 +69,10 @@ RUN set -xe; \
 	apk del .fetch-deps
 
 COPY docker-php-source /usr/local/bin/
-
+# Comments can't be on a multiline in Docker version >1.13
+# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
@@ -87,11 +90,8 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
-# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
-# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
 		--enable-mbstring \
-# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
 		\
 		--with-curl \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -67,6 +67,10 @@ RUN set -xe; \
 
 COPY docker-php-source /usr/local/bin/
 
+# Comments cannot be on a multi-line command
+# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
@@ -86,11 +90,8 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
-# --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
-# --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
 		--enable-mbstring \
-# --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
 		\
 		--with-curl \


### PR DESCRIPTION
Docker rejects multi-line commands which contain a comment:
The error is:
Martyns-MBP:5.6 martyn$ docker build .
Sending build context to Docker daemon 96.77 kB
Error response from daemon: Unknown instruction: --ENABLE-FTP

Or:
Martyns-MBP:5.6 martyn$ docker build .
Sending build context to Docker daemon 96.77 kB
Error response from daemon: Unknown instruction:  &&