### PR TITLE
Swap CFLAGS to PHP_CLFAGS

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -38,9 +38,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -94,6 +94,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -43,9 +43,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -95,6 +95,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/alpine/docker-php-ext-configure
+++ b/5.6/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/alpine/docker-php-ext-install
+++ b/5.6/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -94,9 +94,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --with-apxs2
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -150,6 +150,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/apache/docker-php-ext-configure
+++ b/5.6/apache/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/apache/docker-php-ext-install
+++ b/5.6/apache/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/docker-php-ext-configure
+++ b/5.6/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/docker-php-ext-install
+++ b/5.6/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -39,9 +39,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-gr
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -95,6 +95,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -44,9 +44,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-gr
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -96,6 +96,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/fpm/alpine/docker-php-ext-configure
+++ b/5.6/fpm/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/fpm/alpine/docker-php-ext-install
+++ b/5.6/fpm/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/fpm/docker-php-ext-configure
+++ b/5.6/fpm/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/fpm/docker-php-ext-install
+++ b/5.6/fpm/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/zts/Dockerfile
+++ b/5.6/zts/Dockerfile
@@ -39,9 +39,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -95,6 +95,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -44,9 +44,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 0BD78B5F97500D450838F95DFE857D9A90D90EC1 6E4F6AB321FDC07F2C332E3AC2BF0BC433CFC8B3
 
@@ -96,6 +96,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/5.6/zts/alpine/docker-php-ext-configure
+++ b/5.6/zts/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/zts/alpine/docker-php-ext-install
+++ b/5.6/zts/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/zts/docker-php-ext-configure
+++ b/5.6/zts/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/5.6/zts/docker-php-ext-install
+++ b/5.6/zts/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -38,9 +38,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -94,6 +94,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -43,9 +43,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -95,6 +95,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/alpine/docker-php-ext-configure
+++ b/7.0/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/alpine/docker-php-ext-install
+++ b/7.0/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -94,9 +94,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --with-apxs2
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -150,6 +150,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/apache/docker-php-ext-configure
+++ b/7.0/apache/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/apache/docker-php-ext-install
+++ b/7.0/apache/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/docker-php-ext-configure
+++ b/7.0/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/docker-php-ext-install
+++ b/7.0/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -39,9 +39,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-gr
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -95,6 +95,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -44,9 +44,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-gr
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -96,6 +96,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/fpm/alpine/docker-php-ext-configure
+++ b/7.0/fpm/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/fpm/alpine/docker-php-ext-install
+++ b/7.0/fpm/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/fpm/docker-php-ext-configure
+++ b/7.0/fpm/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/fpm/docker-php-ext-install
+++ b/7.0/fpm/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/zts/Dockerfile
+++ b/7.0/zts/Dockerfile
@@ -39,9 +39,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -95,6 +95,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -44,9 +44,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1A4E8B7277C42E53DBA9C7B9BCAA30EA9C0D5763
 
@@ -96,6 +96,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.0/zts/alpine/docker-php-ext-configure
+++ b/7.0/zts/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/zts/alpine/docker-php-ext-install
+++ b/7.0/zts/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/zts/docker-php-ext-configure
+++ b/7.0/zts/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.0/zts/docker-php-ext-install
+++ b/7.0/zts/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -38,9 +38,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -94,6 +94,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -43,9 +43,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -95,6 +95,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/alpine/docker-php-ext-configure
+++ b/7.1/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/alpine/docker-php-ext-install
+++ b/7.1/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -94,9 +94,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --with-apxs2
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -150,6 +150,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/apache/docker-php-ext-configure
+++ b/7.1/apache/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/apache/docker-php-ext-install
+++ b/7.1/apache/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/docker-php-ext-configure
+++ b/7.1/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/docker-php-ext-install
+++ b/7.1/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -39,9 +39,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-gr
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -95,6 +95,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/fpm/alpine/Dockerfile
+++ b/7.1/fpm/alpine/Dockerfile
@@ -44,9 +44,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-gr
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -96,6 +96,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/fpm/alpine/docker-php-ext-configure
+++ b/7.1/fpm/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/fpm/alpine/docker-php-ext-install
+++ b/7.1/fpm/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/fpm/docker-php-ext-configure
+++ b/7.1/fpm/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/fpm/docker-php-ext-install
+++ b/7.1/fpm/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/zts/Dockerfile
+++ b/7.1/zts/Dockerfile
@@ -39,9 +39,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -95,6 +95,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/zts/alpine/Dockerfile
+++ b/7.1/zts/alpine/Dockerfile
@@ -44,9 +44,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
 
@@ -96,6 +96,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/7.1/zts/alpine/docker-php-ext-configure
+++ b/7.1/zts/alpine/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/zts/alpine/docker-php-ext-install
+++ b/7.1/zts/alpine/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/zts/docker-php-ext-configure
+++ b/7.1/zts/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/7.1/zts/docker-php-ext-install
+++ b/7.1/zts/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -37,9 +37,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS %%GPG_KEYS%%
 
@@ -89,6 +89,9 @@ RUN set -xe \
 		openssl-dev \
 		sqlite-dev \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -32,9 +32,9 @@ RUN mkdir -p $PHP_INI_DIR/conf.d
 # Enable linker optimization (this sorts the hash buckets to improve cache locality, and is non-default)
 # Adds GNU HASH segments to generated executables (this is used if present, and is much faster than sysv hash; in this configuration, sysv hash is also generated)
 # https://github.com/docker-library/php/issues/272
-ENV CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
-ENV CPPFLAGS="$CFLAGS"
-ENV LDFLAGS="-Wl,-O1 -Wl,--hash-style=both"
+ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CPPFLAGS="$PHP_CFLAGS"
+ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS %%GPG_KEYS%%
 
@@ -88,6 +88,9 @@ RUN set -xe \
 	" \
 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends && rm -rf /var/lib/apt/lists/* \
 	\
+	&& export CFLAGS="$PHP_CFLAGS" \
+		CPPFLAGS="$PHP_CPPFLAGS" \
+		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
 	&& ./configure \

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
 srcExists=
 if [ -d /usr/src/php ]; then
 	srcExists=1


### PR DESCRIPTION
Closes #351; Fixes #347.

This will ensure we don't break other downstream builds and lets us use the flags for the php build and any of the contained php modules that can be built with the `docker-php-ext=*` scripts.  When using `docker-php-ext-*` scripts, if a user supplies `CLFAGS`, `CPPFLAGS`, or `LDFLAGS` in their environment it will not be overridden by the respective `PHP_` variable.

Also add `-pie` so that the linker knows too. (see https://github.com/docker-library/php/pull/351#issuecomment-266585986)

First commit updates just the templates; second commit is `update.sh`.