### PR TITLE
Support HTTPS environment variable via x-forwarded-proto header

### DIFF
--- a/apache-Dockerfile-block-1
+++ b/apache-Dockerfile-block-1
@@ -49,6 +49,8 @@ RUN { \
 		echo '\tOptions -Indexes'; \
 		echo '\tAllowOverride All'; \
 		echo '</Directory>'; \
+		echo; \
+		echo 'SetEnvIf x-forwarded-proto https HTTPS=on'; \
 	} | tee "$APACHE_CONFDIR/conf-available/docker-php.conf" \
 	&& a2enconf docker-php
 


### PR DESCRIPTION
When generating fully-qualified links and redirect URLs, php apps typically use server environment variable "HTTPS" to check whether to redirect to https or http. With apache this variable is set by mod_ssl (http://httpd.apache.org/docs/current/mod/mod_ssl.html#envvars).

If on other hand, SSL termination happens before the http request reaches the server where php is running then this information is lost, unless it's carried over, typically by x-forwarded-* headers.

With this change if request is e.g. forwarded to the docker container via mod_proxy in another apache:

    ProxyPass / http://localhost4:9080/
    RequestHeader set X-Forwarded-Proto "https"

Then dockerized php sees that $_SERVER[HTTPS]='on'.

In my usecase this was required for dockerized Drupal 8 to stop redirecting the user to http which wasn't even open in the firewall. (Typically proposed fix for this on SO and drupal forums is to add redirects to .htaccess which 1) wouldn't work unless port 80 was open, 2) is a potential security issue due to requests being made in cleartext, 3) POST request breaks if it receives a redirect response, 4) it's unnecessary and ugly.)