### PR TITLE
#397: Added missing initial slash when replacing wrong pool config path from php-fpm.conf.default.

### DIFF
--- a/fpm-Dockerfile-block-2
+++ b/fpm-Dockerfile-block-2
@@ -4,7 +4,7 @@ RUN set -ex \
 	&& cd /usr/local/etc \
 	&& if [ -d php-fpm.d ]; then \
 		# for some reason, upstream's php-fpm.conf.default has "include=NONE/etc/php-fpm.d/*.conf"
-		sed 's!=NONE/!=!g' php-fpm.conf.default | tee php-fpm.conf > /dev/null; \
+		sed 's!=NONE/!=/!g' php-fpm.conf.default | tee php-fpm.conf > /dev/null; \
 		cp php-fpm.d/www.conf.default php-fpm.d/www.conf; \
 	else \
 		# PHP 5.x doesn't use "include=" by default, so we'll create our own simple config that mimics PHP 7+ for consistency


### PR DESCRIPTION
Fixes https://github.com/docker-library/php/issues/397 .