### PR TITLE
Install "binutils" in "docker-php-ext-enable" if needed

### DIFF
--- a/5.6/alpine/docker-php-ext-enable
+++ b/5.6/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/5.6/apache/docker-php-ext-enable
+++ b/5.6/apache/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/5.6/docker-php-ext-enable
+++ b/5.6/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/5.6/fpm/alpine/docker-php-ext-enable
+++ b/5.6/fpm/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/5.6/fpm/docker-php-ext-enable
+++ b/5.6/fpm/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/5.6/zts/alpine/docker-php-ext-enable
+++ b/5.6/zts/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/5.6/zts/docker-php-ext-enable
+++ b/5.6/zts/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/alpine/docker-php-ext-enable
+++ b/7.0/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/apache/docker-php-ext-enable
+++ b/7.0/apache/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/docker-php-ext-enable
+++ b/7.0/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/fpm/alpine/docker-php-ext-enable
+++ b/7.0/fpm/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/fpm/docker-php-ext-enable
+++ b/7.0/fpm/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/zts/alpine/docker-php-ext-enable
+++ b/7.0/zts/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.0/zts/docker-php-ext-enable
+++ b/7.0/zts/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/alpine/docker-php-ext-enable
+++ b/7.1/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/apache/docker-php-ext-enable
+++ b/7.1/apache/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/docker-php-ext-enable
+++ b/7.1/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/fpm/alpine/docker-php-ext-enable
+++ b/7.1/fpm/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/fpm/docker-php-ext-enable
+++ b/7.1/fpm/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/zts/alpine/docker-php-ext-enable
+++ b/7.1/zts/alpine/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/7.1/zts/docker-php-ext-enable
+++ b/7.1/zts/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -57,6 +57,23 @@ if [ -z "$modules" ]; then
 	exit 1
 fi
 
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+	pm='apk'
+fi
+
+apkDel=
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apkDel='.docker-php-ext-enable-deps'
+	fi
+fi
+
 for module in $modules; do
 	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
@@ -81,3 +98,7 @@ for module in $modules; do
 		echo "$line" >> "$ini"
 	fi
 done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del $apkDel
+fi


### PR DESCRIPTION
This matches the behavior of `docker-php-ext-configure` and `docker-php-ext-install`, and ensures that `nm` is installed and then removed in Alpine where necessary.

Closes #417
Closes #419