### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -88,6 +89,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -99,7 +101,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -116,6 +120,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -89,10 +90,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -100,7 +103,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -118,8 +123,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/5.6/alpine/docker-php-ext-configure
+++ b/5.6/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -147,6 +148,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -158,7 +160,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -175,6 +179,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/5.6/apache/docker-php-ext-configure
+++ b/5.6/apache/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/5.6/docker-php-ext-configure
+++ b/5.6/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -89,6 +90,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -100,7 +102,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -117,6 +121,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -90,10 +91,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -101,7 +104,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -119,8 +124,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/5.6/fpm/alpine/docker-php-ext-configure
+++ b/5.6/fpm/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/5.6/fpm/docker-php-ext-configure
+++ b/5.6/fpm/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/5.6/zts/Dockerfile
+++ b/5.6/zts/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -89,6 +90,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -100,7 +102,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -117,6 +121,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -90,10 +91,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -101,7 +104,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -119,8 +124,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/5.6/zts/alpine/docker-php-ext-configure
+++ b/5.6/zts/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/5.6/zts/docker-php-ext-configure
+++ b/5.6/zts/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -88,6 +89,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -99,7 +101,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -116,6 +120,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -89,10 +90,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -100,7 +103,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -118,8 +123,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.0/alpine/docker-php-ext-configure
+++ b/7.0/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -147,6 +148,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -158,7 +160,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -175,6 +179,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.0/apache/docker-php-ext-configure
+++ b/7.0/apache/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/docker-php-ext-configure
+++ b/7.0/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -89,6 +90,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -100,7 +102,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -117,6 +121,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -90,10 +91,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -101,7 +104,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -119,8 +124,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.0/fpm/alpine/docker-php-ext-configure
+++ b/7.0/fpm/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/fpm/docker-php-ext-configure
+++ b/7.0/fpm/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/zts/Dockerfile
+++ b/7.0/zts/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -89,6 +90,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -100,7 +102,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -117,6 +121,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -90,10 +91,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -101,7 +104,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -119,8 +124,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.0/zts/alpine/docker-php-ext-configure
+++ b/7.0/zts/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.0/zts/docker-php-ext-configure
+++ b/7.0/zts/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -88,6 +89,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -99,7 +101,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -116,6 +120,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -89,10 +90,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -100,7 +103,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -118,8 +123,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/alpine/docker-php-ext-configure
+++ b/7.1/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -147,6 +148,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -158,7 +160,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -175,6 +179,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.1/apache/docker-php-ext-configure
+++ b/7.1/apache/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/docker-php-ext-configure
+++ b/7.1/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -89,6 +90,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -100,7 +102,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -117,6 +121,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.1/fpm/alpine/Dockerfile
+++ b/7.1/fpm/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -90,10 +91,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -101,7 +104,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -119,8 +124,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/fpm/alpine/docker-php-ext-configure
+++ b/7.1/fpm/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/fpm/docker-php-ext-configure
+++ b/7.1/fpm/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/zts/Dockerfile
+++ b/7.1/zts/Dockerfile
@@ -9,6 +9,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -89,6 +90,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -100,7 +102,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -117,6 +121,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/7.1/zts/alpine/Dockerfile
+++ b/7.1/zts/alpine/Dockerfile
@@ -9,6 +9,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -90,10 +91,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -101,7 +104,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -119,8 +124,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/zts/alpine/docker-php-ext-configure
+++ b/7.1/zts/alpine/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/7.1/zts/docker-php-ext-configure
+++ b/7.1/zts/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -3,6 +3,7 @@ FROM alpine:3.4
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev dpkg \
 		file \
 		g++ \
 		gcc \
@@ -83,10 +84,12 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		curl-dev \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
+		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \
@@ -94,7 +97,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -112,8 +117,12 @@ RUN set -xe \
 		--with-openssl \
 		--with-zlib \
 		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
-	&& make -j "$(getconf _NPROCESSORS_ONLN)" \
+	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -3,6 +3,7 @@ FROM debian:jessie
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \
+		dpkg-dev \
 		file \
 		g++ \
 		gcc \
@@ -82,6 +83,7 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
+		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \
@@ -93,7 +95,9 @@ RUN set -xe \
 		LDFLAGS="$PHP_LDFLAGS" \
 	&& docker-php-source extract \
 	&& cd /usr/src/php \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 	&& ./configure \
+		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
@@ -110,6 +114,11 @@ RUN set -xe \
 		--with-libedit \
 		--with-openssl \
 		--with-zlib \
+		\
+# bundled pcre is too old for s390x (which isn't exactly a good sign)
+# /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:65:2: error: #error Unsupported architecture
+		--with-pcre-regex=/usr \
+		--with-libdir="lib/$gnuArch" \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -52,6 +52,11 @@ if [ "$pm" = 'apk' ]; then
 	fi
 fi
 
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
 set -x
 cd "$ext"
 phpize


### PR DESCRIPTION
This is along the same lines as:

- https://github.com/docker-library/postgres/pull/284
- https://github.com/docker-library/python/pull/198
- https://github.com/docker-library/ruby/pull/127
- https://github.com/docker-library/tomcat/pull/70
- https://github.com/docker-library/memcached/pull/13
- https://github.com/tianon/docker-bash/pull/3

Here's some output from inside a container on `s390x` after doing `docker-php-ext-install pdo pdo_mysql`:
```console
/ # uname -m
s390x
/ # php -i | grep pdo
Additional .ini files parsed => /usr/local/etc/php/conf.d/docker-php-ext-pdo_mysql.ini
API Extensions => pdo_mysql
pdo_mysql
pdo_mysql.default_socket => no value => no value
pdo_sqlite
```
(and the same test produced the same output with a Debian variant instead of Alpine)