### PR TITLE
Add pcre-dev library to PHPize dependency list

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -89,7 +90,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -95,7 +96,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -148,7 +149,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -90,7 +91,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -96,7 +97,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/5.6/zts/Dockerfile
+++ b/5.6/zts/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -90,7 +91,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/5.6/zts/Dockerfile
+++ b/5.6/zts/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -96,7 +97,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -89,7 +90,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -95,7 +96,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -148,7 +149,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -90,7 +91,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -96,7 +97,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/7.0/zts/Dockerfile
+++ b/7.0/zts/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -90,7 +91,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.0/zts/Dockerfile
+++ b/7.0/zts/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -96,7 +97,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -89,7 +90,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -95,7 +96,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -148,7 +149,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -90,7 +91,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.1/fpm/alpine/Dockerfile
+++ b/7.1/fpm/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -96,7 +97,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.1/fpm/alpine/Dockerfile
+++ b/7.1/fpm/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/7.1/zts/Dockerfile
+++ b/7.1/zts/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -90,7 +91,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/7.1/zts/Dockerfile
+++ b/7.1/zts/Dockerfile
@@ -14,9 +14,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \

--- a/7.1/zts/alpine/Dockerfile
+++ b/7.1/zts/alpine/Dockerfile
@@ -16,6 +16,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -96,7 +97,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.1/zts/alpine/Dockerfile
+++ b/7.1/zts/alpine/Dockerfile
@@ -15,8 +15,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -10,6 +10,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkgconf \
+		pcre-dev \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \
@@ -89,7 +90,6 @@ RUN set -xe \
 		libedit-dev \
 		libxml2-dev \
 		openssl-dev \
-		pcre-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -9,8 +9,8 @@ ENV PHPIZE_DEPS \
 		gcc \
 		libc-dev \
 		make \
-		pkgconf \
 		pcre-dev \
+		pkgconf \
 		re2c
 RUN apk add --no-cache --virtual .persistent-deps \
 		ca-certificates \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -10,6 +10,7 @@ ENV PHPIZE_DEPS \
 		libc-dev \
 		make \
 		pkg-config \
+		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
@@ -83,7 +84,6 @@ RUN set -xe \
 		$PHP_EXTRA_BUILD_DEPS \
 		libcurl4-openssl-dev \
 		libedit-dev \
-		libpcre3-dev \
 		libsqlite3-dev \
 		libssl-dev \
 		libxml2-dev \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -8,9 +8,9 @@ ENV PHPIZE_DEPS \
 		g++ \
 		gcc \
 		libc-dev \
+		libpcre3-dev \
 		make \
 		pkg-config \
-		libpcre3-dev \
 		re2c
 RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \


### PR DESCRIPTION
After #429 was merged, `pcre-dev` library is required to install any PHP extension: it doesn't matter if the extension is provided with PHP source or not (eg. #432 )

Fixes #432