### PR TITLE
Reduced image size by 50%

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/5.6/alpine/docker-php-source
+++ b/5.6/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/5.6/apache/Dockerfile
+++ b/5.6/apache/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/5.6/apache/docker-php-source
+++ b/5.6/apache/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/5.6/docker-php-source
+++ b/5.6/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/5.6/fpm/Dockerfile
+++ b/5.6/fpm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/5.6/fpm/alpine/docker-php-source
+++ b/5.6/fpm/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/5.6/fpm/docker-php-source
+++ b/5.6/fpm/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/5.6/zts/Dockerfile
+++ b/5.6/zts/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/5.6/zts/alpine/docker-php-source
+++ b/5.6/zts/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/5.6/zts/docker-php-source
+++ b/5.6/zts/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.0/alpine/docker-php-source
+++ b/7.0/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.0/apache/docker-php-source
+++ b/7.0/apache/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/docker-php-source
+++ b/7.0/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.0/fpm/alpine/docker-php-source
+++ b/7.0/fpm/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/fpm/docker-php-source
+++ b/7.0/fpm/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/zts/Dockerfile
+++ b/7.0/zts/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.0/zts/alpine/docker-php-source
+++ b/7.0/zts/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.0/zts/docker-php-source
+++ b/7.0/zts/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.1/alpine/docker-php-source
+++ b/7.1/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/apache/Dockerfile
+++ b/7.1/apache/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.1/apache/docker-php-source
+++ b/7.1/apache/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/docker-php-source
+++ b/7.1/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/fpm/Dockerfile
+++ b/7.1/fpm/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.1/fpm/alpine/docker-php-source
+++ b/7.1/fpm/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/fpm/docker-php-source
+++ b/7.1/fpm/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/zts/Dockerfile
+++ b/7.1/zts/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -19,7 +19,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/7.1/zts/alpine/docker-php-source
+++ b/7.1/zts/alpine/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/7.1/zts/docker-php-source
+++ b/7.1/zts/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
@@ -13,7 +13,6 @@ ENV PHPIZE_DEPS \
 		pkg-config \
 		re2c
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		libedit2 \

--- a/docker-php-source
+++ b/docker-php-source
@@ -20,11 +20,17 @@ case "$1" in
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
 			touch "$dir/.docker-extracted"
+			if [ -e /etc/debian_version ]; then
+				apt-get update && apt-get install -y $PHPIZE_DEPS --no-install-recommends && rm -r /var/lib/apt/lists/*
+			fi
 		fi
 		;;
 
 	delete)
 		rm -rf "$dir"
+		if [ -e /etc/debian_version ]; then
+			apt-get purge -y --auto-remove $PHPIZE_DEPS
+		fi
 		;;
 
 	*)


### PR DESCRIPTION
With two small hacks, the image size can be reduced from 380 to 167 MB
1. Use debian-slim image to save the first 44 MB
2. Only install the build tools, when they are actually needed save another 170 MB