### PR TITLE
Added --progress argument to all apk add on docker-php-ext-* scripts

### DIFF
--- a/5.6/alpine/docker-php-ext-configure
+++ b/5.6/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/alpine/docker-php-ext-enable
+++ b/5.6/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/alpine/docker-php-ext-install
+++ b/5.6/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/5.6/apache/docker-php-ext-configure
+++ b/5.6/apache/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/apache/docker-php-ext-enable
+++ b/5.6/apache/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/apache/docker-php-ext-install
+++ b/5.6/apache/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/5.6/docker-php-ext-configure
+++ b/5.6/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/docker-php-ext-enable
+++ b/5.6/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/docker-php-ext-install
+++ b/5.6/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/5.6/fpm/alpine/docker-php-ext-configure
+++ b/5.6/fpm/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/fpm/alpine/docker-php-ext-enable
+++ b/5.6/fpm/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/fpm/alpine/docker-php-ext-install
+++ b/5.6/fpm/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/5.6/fpm/docker-php-ext-configure
+++ b/5.6/fpm/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/fpm/docker-php-ext-enable
+++ b/5.6/fpm/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/fpm/docker-php-ext-install
+++ b/5.6/fpm/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/5.6/zts/alpine/docker-php-ext-configure
+++ b/5.6/zts/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/zts/alpine/docker-php-ext-enable
+++ b/5.6/zts/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/zts/alpine/docker-php-ext-install
+++ b/5.6/zts/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/5.6/zts/docker-php-ext-configure
+++ b/5.6/zts/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/5.6/zts/docker-php-ext-enable
+++ b/5.6/zts/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/5.6/zts/docker-php-ext-install
+++ b/5.6/zts/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/alpine/docker-php-ext-configure
+++ b/7.0/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/alpine/docker-php-ext-enable
+++ b/7.0/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/alpine/docker-php-ext-install
+++ b/7.0/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/apache/docker-php-ext-configure
+++ b/7.0/apache/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/apache/docker-php-ext-enable
+++ b/7.0/apache/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/apache/docker-php-ext-install
+++ b/7.0/apache/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/docker-php-ext-configure
+++ b/7.0/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/docker-php-ext-enable
+++ b/7.0/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/docker-php-ext-install
+++ b/7.0/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/fpm/alpine/docker-php-ext-configure
+++ b/7.0/fpm/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/fpm/alpine/docker-php-ext-enable
+++ b/7.0/fpm/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/fpm/alpine/docker-php-ext-install
+++ b/7.0/fpm/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/fpm/docker-php-ext-configure
+++ b/7.0/fpm/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/fpm/docker-php-ext-enable
+++ b/7.0/fpm/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/fpm/docker-php-ext-install
+++ b/7.0/fpm/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/zts/alpine/docker-php-ext-configure
+++ b/7.0/zts/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/zts/alpine/docker-php-ext-enable
+++ b/7.0/zts/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/zts/alpine/docker-php-ext-install
+++ b/7.0/zts/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.0/zts/docker-php-ext-configure
+++ b/7.0/zts/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.0/zts/docker-php-ext-enable
+++ b/7.0/zts/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.0/zts/docker-php-ext-install
+++ b/7.0/zts/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/alpine/docker-php-ext-configure
+++ b/7.1/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/alpine/docker-php-ext-enable
+++ b/7.1/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/alpine/docker-php-ext-install
+++ b/7.1/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/apache/docker-php-ext-configure
+++ b/7.1/apache/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/apache/docker-php-ext-enable
+++ b/7.1/apache/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/apache/docker-php-ext-install
+++ b/7.1/apache/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/docker-php-ext-configure
+++ b/7.1/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/docker-php-ext-enable
+++ b/7.1/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/docker-php-ext-install
+++ b/7.1/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/fpm/alpine/docker-php-ext-configure
+++ b/7.1/fpm/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/fpm/alpine/docker-php-ext-enable
+++ b/7.1/fpm/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/fpm/alpine/docker-php-ext-install
+++ b/7.1/fpm/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/fpm/docker-php-ext-configure
+++ b/7.1/fpm/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/fpm/docker-php-ext-enable
+++ b/7.1/fpm/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/fpm/docker-php-ext-install
+++ b/7.1/fpm/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/zts/alpine/docker-php-ext-configure
+++ b/7.1/zts/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/zts/alpine/docker-php-ext-enable
+++ b/7.1/zts/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/zts/alpine/docker-php-ext-install
+++ b/7.1/zts/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.1/zts/docker-php-ext-configure
+++ b/7.1/zts/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.1/zts/docker-php-ext-enable
+++ b/7.1/zts/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.1/zts/docker-php-ext-install
+++ b/7.1/zts/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/alpine/docker-php-ext-configure
+++ b/7.2-rc/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/alpine/docker-php-ext-enable
+++ b/7.2-rc/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/alpine/docker-php-ext-install
+++ b/7.2-rc/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/apache/docker-php-ext-configure
+++ b/7.2-rc/apache/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/apache/docker-php-ext-enable
+++ b/7.2-rc/apache/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/apache/docker-php-ext-install
+++ b/7.2-rc/apache/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/docker-php-ext-configure
+++ b/7.2-rc/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/docker-php-ext-enable
+++ b/7.2-rc/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/docker-php-ext-install
+++ b/7.2-rc/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/fpm/alpine/docker-php-ext-configure
+++ b/7.2-rc/fpm/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/fpm/alpine/docker-php-ext-enable
+++ b/7.2-rc/fpm/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/fpm/alpine/docker-php-ext-install
+++ b/7.2-rc/fpm/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/fpm/docker-php-ext-configure
+++ b/7.2-rc/fpm/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/fpm/docker-php-ext-enable
+++ b/7.2-rc/fpm/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/fpm/docker-php-ext-install
+++ b/7.2-rc/fpm/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/zts/alpine/docker-php-ext-configure
+++ b/7.2-rc/zts/alpine/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/zts/alpine/docker-php-ext-enable
+++ b/7.2-rc/zts/alpine/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/zts/alpine/docker-php-ext-install
+++ b/7.2-rc/zts/alpine/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/7.2-rc/zts/docker-php-ext-configure
+++ b/7.2-rc/zts/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/7.2-rc/zts/docker-php-ext-enable
+++ b/7.2-rc/zts/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/7.2-rc/zts/docker-php-ext-install
+++ b/7.2-rc/zts/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -48,7 +48,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+		apk add --progress --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
 	fi
 fi
 

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -69,7 +69,7 @@ if [ "$pm" = 'apk' ]; then
 		&& ! apk info --installed .phpize-deps > /dev/null \
 		&& ! apk info --installed .phpize-deps-configure > /dev/null \
 	; then
-		apk add --no-cache --virtual '.docker-php-ext-enable-deps' binutils
+		apk add --progress --no-cache --virtual '.docker-php-ext-enable-deps' binutils
 		apkDel='.docker-php-ext-enable-deps'
 	fi
 fi

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -89,7 +89,7 @@ if [ "$pm" = 'apk' ]; then
 		if apk info --installed .phpize-deps-configure > /dev/null; then
 			apkDel='.phpize-deps-configure'
 		elif ! apk info --installed .phpize-deps > /dev/null; then
-			apk add --no-cache --virtual .phpize-deps $PHPIZE_DEPS
+			apk add --progress --no-cache --virtual .phpize-deps $PHPIZE_DEPS
 			apkDel='.phpize-deps'
 		fi
 	fi


### PR DESCRIPTION
This pull request change all docker-ext-* (at least most of them) and add an argument do `apk add`.
Example: `apk add --no-cache` turns `apk add --progress --no-cache`