### PR TITLE
Remove s390x from 7.2+

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -103,6 +103,11 @@ for version in "${versions[@]}"; do
 		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$dir/Dockerfile")"
 		variantArches="${parentRepoToArches[$variantParent]}"
 
+		# 7.2 no longer supports s390x
+		if [[ "$version" = 7.* ]] && [ "$version" != '7.0' ] && [ "$version" != '7.1' ]; then
+			variantArches="$(echo " $variantArches " | sed -r -e 's/ s390x//g')"
+		fi
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
```
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c: In function 'KeccakP1600_AddLanes':
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c:158:22: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
     UINT8 *curData = data;
                      ^~~~
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c: In function 'KeccakP1600_OverwriteBytesInLane':
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c:208:2: error: #error "Not yet implemented"
 #error "Not yet implemented"
  ^~~~~
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c: In function 'KeccakP1600_OverwriteLanes':
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c:229:2: error: #error "Not yet implemented"
 #error "Not yet implemented"
  ^~~~~
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c: In function 'KeccakP1600_OverwriteWithZeroes':
/usr/src/php/ext/hash/sha3/generic64lc/KeccakP-1600-opt64.c:264:2: error: #error "Not yet implemented"
 #error "Not yet implemented"
  ^~~~~
make: *** [ext/hash/sha3/generic64lc/KeccakP-1600-opt64.lo] Error 1
```