### PR TITLE
Remove support for arm32v5 (takes too long to build)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -108,6 +108,9 @@ for version in "${versions[@]}"; do
 			variantArches="$(echo " $variantArches " | sed -r -e 's/ s390x//g')"
 		fi
 
+		# arm32v5 takes _way_ too long to build (on the order of days)
+		variantArches="$(echo " $variantArches " | sed -r -e 's/ arm32v5//g')"
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
See also docker-library/ruby#151, https://github.com/docker-library/python/pull/220.