### PR TITLE
Update Alpine 3.6+ to use "libressl" instead of "openssl"

### DIFF
--- a/5.6/alpine/Dockerfile
+++ b/5.6/alpine/Dockerfile
@@ -94,8 +94,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/5.6/fpm/alpine/Dockerfile
+++ b/5.6/fpm/alpine/Dockerfile
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/5.6/zts/alpine/Dockerfile
+++ b/5.6/zts/alpine/Dockerfile
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -94,8 +94,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.0/fpm/alpine/Dockerfile
+++ b/7.0/fpm/alpine/Dockerfile
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.0/zts/alpine/Dockerfile
+++ b/7.0/zts/alpine/Dockerfile
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.1/alpine/Dockerfile
+++ b/7.1/alpine/Dockerfile
@@ -94,8 +94,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.1/fpm/alpine/Dockerfile
+++ b/7.1/fpm/alpine/Dockerfile
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.1/zts/alpine/Dockerfile
+++ b/7.1/zts/alpine/Dockerfile
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
-		libxml2-dev \
 		openssl-dev \
+		libxml2-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.2-rc/alpine/Dockerfile
+++ b/7.2-rc/alpine/Dockerfile
@@ -59,7 +59,7 @@ RUN set -xe; \
 	\
 	apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		openssl \
+		libressl \
 	; \
 	\
 	mkdir -p /usr/src; \
@@ -94,8 +94,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
+		libressl-dev \
 		libxml2-dev \
-		openssl-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.2-rc/fpm/alpine/Dockerfile
+++ b/7.2-rc/fpm/alpine/Dockerfile
@@ -60,7 +60,7 @@ RUN set -xe; \
 	\
 	apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		openssl \
+		libressl \
 	; \
 	\
 	mkdir -p /usr/src; \
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
+		libressl-dev \
 		libxml2-dev \
-		openssl-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/7.2-rc/zts/alpine/Dockerfile
+++ b/7.2-rc/zts/alpine/Dockerfile
@@ -60,7 +60,7 @@ RUN set -xe; \
 	\
 	apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		openssl \
+		libressl \
 	; \
 	\
 	mkdir -p /usr/src; \
@@ -95,8 +95,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
+		libressl-dev \
 		libxml2-dev \
-		openssl-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -53,7 +53,7 @@ RUN set -xe; \
 	\
 	apk add --no-cache --virtual .fetch-deps \
 		gnupg \
-		openssl \
+		libressl \
 	; \
 	\
 	mkdir -p /usr/src; \
@@ -88,8 +88,8 @@ RUN set -xe \
 		coreutils \
 		curl-dev \
 		libedit-dev \
+		libressl-dev \
 		libxml2-dev \
-		openssl-dev \
 		sqlite-dev \
 	\
 	&& export CFLAGS="$PHP_CFLAGS" \

--- a/update.sh
+++ b/update.sh
@@ -195,6 +195,10 @@ for version in "${versions[@]}"; do
 			"${dockerfiles[@]}"
 	)
 
+	if [ "$alpineVersion" = '3.4' ]; then
+		sed -ri 's!libressl!openssl!g' "${dockerfiles[@]}"
+	fi
+
 	# update entrypoint commands
 	for dockerfile in "${dockerfiles[@]}"; do
 		cmd="$(awk '$1 == "CMD" { $1 = ""; print }' "$dockerfile" | tail -1 | jq --raw-output '.[0]')"


### PR DESCRIPTION
Fixes #494

Thanks @csandanov!