### PR TITLE
Add Argon2 password hashing

### DIFF
--- a/7.2-rc/stretch/apache/Dockerfile
+++ b/7.2-rc/stretch/apache/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
+		libargon2-0 \
 		libedit2 \
 		libsqlite3-0 \
 		libxml2 \
@@ -153,6 +154,7 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
+		libargon2-0-dev \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \
@@ -186,6 +188,8 @@ RUN set -xe \
 		--enable-mbstring \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash (7.2+)
+		--with-password-argon2 \
 		\
 		--with-curl \
 		--with-libedit \

--- a/7.2-rc/stretch/cli/Dockerfile
+++ b/7.2-rc/stretch/cli/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
+		libargon2-0 \
 		libedit2 \
 		libsqlite3-0 \
 		libxml2 \
@@ -94,6 +95,7 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
+		libargon2-0-dev \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \
@@ -127,6 +129,8 @@ RUN set -xe \
 		--enable-mbstring \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash (7.2+)
+		--with-password-argon2 \
 		\
 		--with-curl \
 		--with-libedit \

--- a/7.2-rc/stretch/fpm/Dockerfile
+++ b/7.2-rc/stretch/fpm/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
+		libargon2-0 \
 		libedit2 \
 		libsqlite3-0 \
 		libxml2 \
@@ -95,6 +96,7 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
+		libargon2-0-dev \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \
@@ -128,6 +130,8 @@ RUN set -xe \
 		--enable-mbstring \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash (7.2+)
+		--with-password-argon2 \
 		\
 		--with-curl \
 		--with-libedit \

--- a/7.2-rc/stretch/zts/Dockerfile
+++ b/7.2-rc/stretch/zts/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
+		libargon2-0 \
 		libedit2 \
 		libsqlite3-0 \
 		libxml2 \
@@ -95,6 +96,7 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
+		libargon2-0-dev \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \
@@ -128,6 +130,8 @@ RUN set -xe \
 		--enable-mbstring \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash (7.2+)
+		--with-password-argon2 \
 		\
 		--with-curl \
 		--with-libedit \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
 		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
+		libargon2-0 \
 		libedit2 \
 		libsqlite3-0 \
 		libxml2 \
@@ -88,6 +89,7 @@ COPY docker-php-source /usr/local/bin/
 RUN set -xe \
 	&& buildDeps=" \
 		$PHP_EXTRA_BUILD_DEPS \
+		libargon2-0-dev \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \
@@ -121,6 +123,8 @@ RUN set -xe \
 		--enable-mbstring \
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
+# https://wiki.php.net/rfc/argon2_password_hash (7.2+)
+		--with-password-argon2 \
 		\
 		--with-curl \
 		--with-libedit \


### PR DESCRIPTION
See https://wiki.php.net/rfc/argon2_password_hash

See also https://gitlab.com/deb.sury.org/php/commit/a91992745b62690ef5257cd6597ad0a8d7afe9ff

Closes #515

Technically we can also consider this for Alpine 3.7+ (since they have an `argon2-dev` package in Edge currently), which I've noted in a comment in `update.sh`.