### PR TITLE
Switch from "nm" to "readelf" so that we can detect the "zend_extension_entry" symbol even in stripped objects

### DIFF
--- a/5.6/alpine3.4/cli/docker-php-ext-enable
+++ b/5.6/alpine3.4/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/5.6/alpine3.4/fpm/docker-php-ext-enable
+++ b/5.6/alpine3.4/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/5.6/alpine3.4/zts/docker-php-ext-enable
+++ b/5.6/alpine3.4/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/5.6/jessie/apache/docker-php-ext-enable
+++ b/5.6/jessie/apache/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/5.6/jessie/cli/docker-php-ext-enable
+++ b/5.6/jessie/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/5.6/jessie/fpm/docker-php-ext-enable
+++ b/5.6/jessie/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/5.6/jessie/zts/docker-php-ext-enable
+++ b/5.6/jessie/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/alpine3.4/cli/docker-php-ext-enable
+++ b/7.0/alpine3.4/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/alpine3.4/fpm/docker-php-ext-enable
+++ b/7.0/alpine3.4/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/alpine3.4/zts/docker-php-ext-enable
+++ b/7.0/alpine3.4/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/jessie/apache/docker-php-ext-enable
+++ b/7.0/jessie/apache/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/jessie/cli/docker-php-ext-enable
+++ b/7.0/jessie/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/jessie/fpm/docker-php-ext-enable
+++ b/7.0/jessie/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.0/jessie/zts/docker-php-ext-enable
+++ b/7.0/jessie/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/alpine3.4/cli/docker-php-ext-enable
+++ b/7.1/alpine3.4/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/alpine3.4/fpm/docker-php-ext-enable
+++ b/7.1/alpine3.4/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/alpine3.4/zts/docker-php-ext-enable
+++ b/7.1/alpine3.4/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/jessie/apache/docker-php-ext-enable
+++ b/7.1/jessie/apache/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/jessie/cli/docker-php-ext-enable
+++ b/7.1/jessie/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/jessie/fpm/docker-php-ext-enable
+++ b/7.1/jessie/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.1/jessie/zts/docker-php-ext-enable
+++ b/7.1/jessie/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/alpine3.6/cli/docker-php-ext-enable
+++ b/7.2/alpine3.6/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/alpine3.6/fpm/docker-php-ext-enable
+++ b/7.2/alpine3.6/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/alpine3.6/zts/docker-php-ext-enable
+++ b/7.2/alpine3.6/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/stretch/apache/docker-php-ext-enable
+++ b/7.2/stretch/apache/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/stretch/cli/docker-php-ext-enable
+++ b/7.2/stretch/cli/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/stretch/fpm/docker-php-ext-enable
+++ b/7.2/stretch/fpm/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/7.2/stretch/zts/docker-php-ext-enable
+++ b/7.2/stretch/zts/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -78,7 +78,7 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if nm -g "$module" | grep -q ' zend_extension_entry$'; then
+	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
 		line="zend_extension=$(readlink -f "$module")"
 	else


### PR DESCRIPTION
See also https://github.com/docker-library/php/pull/420#issuecomment-349372144 and the following discussion.