### PR TITLE
Block the installation of Debian's PHP packages

### DIFF
--- a/5.6/jessie/apache/Dockerfile
+++ b/5.6/jessie/apache/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/5.6/jessie/apache/Dockerfile
+++ b/5.6/jessie/apache/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/5.6/jessie/cli/Dockerfile
+++ b/5.6/jessie/cli/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/5.6/jessie/cli/Dockerfile
+++ b/5.6/jessie/cli/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/5.6/jessie/zts/Dockerfile
+++ b/5.6/jessie/zts/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/5.6/jessie/zts/Dockerfile
+++ b/5.6/jessie/zts/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.0/jessie/apache/Dockerfile
+++ b/7.0/jessie/apache/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.0/jessie/apache/Dockerfile
+++ b/7.0/jessie/apache/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.0/jessie/cli/Dockerfile
+++ b/7.0/jessie/cli/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.0/jessie/cli/Dockerfile
+++ b/7.0/jessie/cli/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.0/jessie/zts/Dockerfile
+++ b/7.0/jessie/zts/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.0/jessie/zts/Dockerfile
+++ b/7.0/jessie/zts/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:jessie
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:jessie
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:stretch-slim
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:stretch-slim
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:stretch-slim
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:stretch-slim
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:stretch-slim
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:stretch-slim
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -7,6 +7,7 @@
 FROM debian:stretch-slim
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -6,6 +6,14 @@
 
 FROM debian:stretch-slim
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,6 +1,7 @@
 FROM debian:%%DEBIAN_SUITE%%
 
 # prevent Debian's PHP packages from being installed
+# https://github.com/docker-library/php/pull/542
 RUN set -eux; \
 	{ \
 		echo 'Package: php*'; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,5 +1,13 @@
 FROM debian:%%DEBIAN_SUITE%%
 
+# prevent Debian's PHP packages from being installed
+RUN set -eux; \
+	{ \
+		echo 'Package: php*'; \
+		echo 'Pin: release  *'; \
+		echo 'Pin-Priority: -1'; \
+	} > /etc/apt/preferences.d/no-debian-php
+
 # persistent / runtime deps
 ENV PHPIZE_DEPS \
 		autoconf \


### PR DESCRIPTION
This will hopefully help folks with the confusion around installing packages like "php-apcu" and then wondering why they don't actually "work" (because they pull in Debian's PHP, and that's not what this image packages).