### PR TITLE
Allow FPM pool to listen on IPv4 when IPv6 is disabled

### DIFF
--- a/5.6/alpine3.4/fpm/Dockerfile
+++ b/5.6/alpine3.4/fpm/Dockerfile
@@ -189,7 +189,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -216,7 +216,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.0/alpine3.4/fpm/Dockerfile
+++ b/7.0/alpine3.4/fpm/Dockerfile
@@ -189,7 +189,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -216,7 +216,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.1/alpine3.4/fpm/Dockerfile
+++ b/7.1/alpine3.4/fpm/Dockerfile
@@ -189,7 +189,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -216,7 +216,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.2/alpine3.6/fpm/Dockerfile
+++ b/7.2/alpine3.6/fpm/Dockerfile
@@ -189,7 +189,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.2/alpine3.7/fpm/Dockerfile
+++ b/7.2/alpine3.7/fpm/Dockerfile
@@ -189,7 +189,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -219,7 +219,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000

--- a/fpm-Dockerfile-block-2
+++ b/fpm-Dockerfile-block-2
@@ -33,7 +33,7 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = [::]:9000'; \
+		echo 'listen = 9000'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 EXPOSE 9000


### PR DESCRIPTION
In PHP 7.2.1 [a change][] was made in response to bug [#74166][] to fall back to listening on 0.0.0.0 if IPv6 is disabled (for example with `ipv6.disable=1` Linux kernel param) instead of failing to create a listening socket with the error "Address family not supported by protocol (97)".

A fallback to IPv4 in such circumstances is only possible in PHP >= 7.2.1 and by specifying a port number without an address to the `listen` directive.

It isn't clear to me how to update the Dockerfiles with this template change, but am happy to do so if pointed in the right direction.

[a change]: https://github.com/php/php-src/commit/b63c45c69e3a97b05314c6f3328a0ff695e28d36
[#74166]: https://bugs.php.net/bug.php?id=74166 "IPv6 forced to be enabled"