### PR TITLE
Ensure required libressl/openssl default parameter are set

### DIFF
--- a/5.6/alpine3.4/cli/Dockerfile
+++ b/5.6/alpine3.4/cli/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/5.6/alpine3.4/fpm/Dockerfile
+++ b/5.6/alpine3.4/fpm/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/5.6/alpine3.4/zts/Dockerfile
+++ b/5.6/alpine3.4/zts/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.0/alpine3.4/cli/Dockerfile
+++ b/7.0/alpine3.4/cli/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.0/alpine3.4/fpm/Dockerfile
+++ b/7.0/alpine3.4/fpm/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.0/alpine3.4/zts/Dockerfile
+++ b/7.0/alpine3.4/zts/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.1/alpine3.4/cli/Dockerfile
+++ b/7.1/alpine3.4/cli/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.1/alpine3.4/fpm/Dockerfile
+++ b/7.1/alpine3.4/fpm/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.1/alpine3.4/zts/Dockerfile
+++ b/7.1/alpine3.4/zts/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.2/alpine3.6/cli/Dockerfile
+++ b/7.2/alpine3.6/cli/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.2/alpine3.6/fpm/Dockerfile
+++ b/7.2/alpine3.6/fpm/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.2/alpine3.6/zts/Dockerfile
+++ b/7.2/alpine3.6/zts/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.2/alpine3.7/cli/Dockerfile
+++ b/7.2/alpine3.7/cli/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.2/alpine3.7/fpm/Dockerfile
+++ b/7.2/alpine3.7/fpm/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/7.2/alpine3.7/zts/Dockerfile
+++ b/7.2/alpine3.7/zts/Dockerfile
@@ -25,6 +25,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -19,6 +19,8 @@ RUN apk add --no-cache --virtual .persistent-deps \
 # https://github.com/docker-library/php/issues/494
 		libressl
 
+RUN sed -i 's/#default_bits/default_bits/g; s/#default_md/default_md/g' /etc/ssl/openssl.cnf
+
 # ensure www-data user exists
 RUN set -x \
 	&& addgroup -g 82 -S www-data \


### PR DESCRIPTION
If  default_bits and default_md are not set, openssl_pkey_new()
won't return a key without additional configuration.

LibreSSL has commented them out.

Fixes: #569
See: https://forge.typo3.org/issues/83643