### PR TITLE
Reduce broken TravisCI builds by using ipv4-only sks-keyserver pool

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -72,7 +72,7 @@ RUN set -xe; \
 		wget -O php.tar.xz.asc "$PHP_ASC_URL"; \
 		export GNUPGHOME="$(mktemp -d)"; \
 		for key in $GPG_KEYS; do \
-			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+			gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
 		rm -rf "$GNUPGHOME"; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -80,7 +80,7 @@ RUN set -xe; \
 		wget -O php.tar.xz.asc "$PHP_ASC_URL"; \
 		export GNUPGHOME="$(mktemp -d)"; \
 		for key in $GPG_KEYS; do \
-			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+			gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
 		rm -rf "$GNUPGHOME"; \


### PR DESCRIPTION
When submitting my [previous PR](https://github.com/docker-library/php/pull/601) I noticed that both the current master branch and my PR CI build failed due to the gpg keyserver address not being found, and found this [similar issue.](https://github.com/nodejs/docker-node/issues/380#issuecomment-306451705)

TL;DR Docker containers don't generally have access to IPv6, sometimes ha.pool.sks-keyservers.net gives IPv6 addresses to use for GPG. Changing the pool to [only return IPv4](https://sks-keyservers.net/overview-of-pools.php#pool_ipv4) addresses should fix this.