### PR TITLE
Add "--with-mhash"

### DIFF
--- a/5.6/alpine3.4/cli/Dockerfile
+++ b/5.6/alpine3.4/cli/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/5.6/alpine3.4/cli/Dockerfile
+++ b/5.6/alpine3.4/cli/Dockerfile
@@ -115,7 +115,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/5.6/alpine3.4/fpm/Dockerfile
+++ b/5.6/alpine3.4/fpm/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/5.6/alpine3.4/fpm/Dockerfile
+++ b/5.6/alpine3.4/fpm/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/5.6/alpine3.4/zts/Dockerfile
+++ b/5.6/alpine3.4/zts/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/5.6/alpine3.4/zts/Dockerfile
+++ b/5.6/alpine3.4/zts/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/5.6/jessie/apache/Dockerfile
+++ b/5.6/jessie/apache/Dockerfile
@@ -193,6 +193,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/5.6/jessie/cli/Dockerfile
+++ b/5.6/jessie/cli/Dockerfile
@@ -134,6 +134,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/5.6/jessie/zts/Dockerfile
+++ b/5.6/jessie/zts/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/alpine3.4/cli/Dockerfile
+++ b/7.0/alpine3.4/cli/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/alpine3.4/cli/Dockerfile
+++ b/7.0/alpine3.4/cli/Dockerfile
@@ -115,7 +115,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.0/alpine3.4/fpm/Dockerfile
+++ b/7.0/alpine3.4/fpm/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.0/alpine3.4/fpm/Dockerfile
+++ b/7.0/alpine3.4/fpm/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/alpine3.4/zts/Dockerfile
+++ b/7.0/alpine3.4/zts/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.0/alpine3.4/zts/Dockerfile
+++ b/7.0/alpine3.4/zts/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/jessie/apache/Dockerfile
+++ b/7.0/jessie/apache/Dockerfile
@@ -193,6 +193,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/jessie/cli/Dockerfile
+++ b/7.0/jessie/cli/Dockerfile
@@ -134,6 +134,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.0/jessie/zts/Dockerfile
+++ b/7.0/jessie/zts/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/alpine3.4/cli/Dockerfile
+++ b/7.1/alpine3.4/cli/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/alpine3.4/cli/Dockerfile
+++ b/7.1/alpine3.4/cli/Dockerfile
@@ -115,7 +115,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.1/alpine3.4/fpm/Dockerfile
+++ b/7.1/alpine3.4/fpm/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.1/alpine3.4/fpm/Dockerfile
+++ b/7.1/alpine3.4/fpm/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/alpine3.4/zts/Dockerfile
+++ b/7.1/alpine3.4/zts/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.1/alpine3.4/zts/Dockerfile
+++ b/7.1/alpine3.4/zts/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -193,6 +193,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -134,6 +134,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.6/cli/Dockerfile
+++ b/7.2/alpine3.6/cli/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.2/alpine3.6/cli/Dockerfile
+++ b/7.2/alpine3.6/cli/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.6/fpm/Dockerfile
+++ b/7.2/alpine3.6/fpm/Dockerfile
@@ -116,6 +116,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.6/fpm/Dockerfile
+++ b/7.2/alpine3.6/fpm/Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.2/alpine3.6/zts/Dockerfile
+++ b/7.2/alpine3.6/zts/Dockerfile
@@ -116,6 +116,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.6/zts/Dockerfile
+++ b/7.2/alpine3.6/zts/Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.2/alpine3.7/cli/Dockerfile
+++ b/7.2/alpine3.7/cli/Dockerfile
@@ -116,7 +116,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.2/alpine3.7/cli/Dockerfile
+++ b/7.2/alpine3.7/cli/Dockerfile
@@ -115,6 +115,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.7/fpm/Dockerfile
+++ b/7.2/alpine3.7/fpm/Dockerfile
@@ -116,6 +116,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.7/fpm/Dockerfile
+++ b/7.2/alpine3.7/fpm/Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.2/alpine3.7/zts/Dockerfile
+++ b/7.2/alpine3.7/zts/Dockerfile
@@ -116,6 +116,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/alpine3.7/zts/Dockerfile
+++ b/7.2/alpine3.7/zts/Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -195,6 +195,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -136,6 +136,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -137,6 +137,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -137,6 +137,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--with-mhash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -109,6 +109,9 @@ RUN set -xe \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -110,7 +110,7 @@ RUN set -xe \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -131,7 +131,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439
-		--disable-hash \
+		--with-mhash \
 		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -130,6 +130,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/issues/439
+		--disable-hash \
+		\
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)


### PR DESCRIPTION
This allows for users of the image to `docker-php-ext-configure hash --with-mhash`, for example.

Closes #439