### PR TITLE
Add "--enable-option-checking=fatal" to ./configure invocations

### DIFF
--- a/5.6/alpine3.4/cli/Dockerfile
+++ b/5.6/alpine3.4/cli/Dockerfile
@@ -112,6 +112,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/5.6/alpine3.4/fpm/Dockerfile
+++ b/5.6/alpine3.4/fpm/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/5.6/alpine3.4/zts/Dockerfile
+++ b/5.6/alpine3.4/zts/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/5.6/jessie/apache/Dockerfile
+++ b/5.6/jessie/apache/Dockerfile
@@ -191,6 +191,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/5.6/jessie/cli/Dockerfile
+++ b/5.6/jessie/cli/Dockerfile
@@ -132,6 +132,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -133,6 +133,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/5.6/jessie/zts/Dockerfile
+++ b/5.6/jessie/zts/Dockerfile
@@ -133,6 +133,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/alpine3.4/cli/Dockerfile
+++ b/7.0/alpine3.4/cli/Dockerfile
@@ -112,6 +112,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/alpine3.4/fpm/Dockerfile
+++ b/7.0/alpine3.4/fpm/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/alpine3.4/zts/Dockerfile
+++ b/7.0/alpine3.4/zts/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/jessie/apache/Dockerfile
+++ b/7.0/jessie/apache/Dockerfile
@@ -191,6 +191,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/jessie/cli/Dockerfile
+++ b/7.0/jessie/cli/Dockerfile
@@ -132,6 +132,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -133,6 +133,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.0/jessie/zts/Dockerfile
+++ b/7.0/jessie/zts/Dockerfile
@@ -133,6 +133,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/alpine3.4/cli/Dockerfile
+++ b/7.1/alpine3.4/cli/Dockerfile
@@ -112,6 +112,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/alpine3.4/fpm/Dockerfile
+++ b/7.1/alpine3.4/fpm/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/alpine3.4/zts/Dockerfile
+++ b/7.1/alpine3.4/zts/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -191,6 +191,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -132,6 +132,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -133,6 +133,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -133,6 +133,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/alpine3.6/cli/Dockerfile
+++ b/7.2/alpine3.6/cli/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/alpine3.6/fpm/Dockerfile
+++ b/7.2/alpine3.6/fpm/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/alpine3.6/zts/Dockerfile
+++ b/7.2/alpine3.6/zts/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/alpine3.7/cli/Dockerfile
+++ b/7.2/alpine3.7/cli/Dockerfile
@@ -113,6 +113,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/alpine3.7/fpm/Dockerfile
+++ b/7.2/alpine3.7/fpm/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/alpine3.7/zts/Dockerfile
+++ b/7.2/alpine3.7/zts/Dockerfile
@@ -114,6 +114,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -193,6 +193,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -134,6 +134,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -135,6 +135,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -107,6 +107,9 @@ RUN set -xe \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -128,6 +128,9 @@ RUN set -eux; \
 		--with-config-file-path="$PHP_INI_DIR" \
 		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
 		\
+# make sure invalid --configure-flags are fatal errors intead of just warnings
+		--enable-option-checking=fatal \
+		\
 		--disable-cgi \
 		\
 # https://github.com/docker-library/php/issues/439


### PR DESCRIPTION
This will help stop things like https://github.com/docker-library/php/pull/526 from getting so far into the build before we discover that the configure flag isn't even supported.

```console
root@f8fe2e89eef1:/usr/src/php# ./configure --enable-option-checking=fatal --without-pcre-jit
configure: error: unrecognized options: --without-pcre-jit
root@f8fe2e89eef1:/usr/src/php# 
```