### PR TITLE
Make apache listen on localhost, not on docker IP

### DIFF
--- a/apache-Dockerfile-block-1
+++ b/apache-Dockerfile-block-1
@@ -55,5 +55,8 @@ RUN { \
 	} | tee "$APACHE_CONFDIR/conf-available/docker-php.conf" \
 	&& a2enconf docker-php
 
+# Listen on localhost
+RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
+
 ENV PHP_EXTRA_BUILD_DEPS apache2-dev
 ENV PHP_EXTRA_CONFIGURE_ARGS --with-apxs2


### PR DESCRIPTION
Otherwise you would see this when starting the container:

```
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName'
 directive globally to suppress this message
```

In my case, `172.17.0.2` is internal Docker network IP.