### PR TITLE
fix build failure: delete ~/.pearrc return 137

### DIFF
--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -190,7 +190,7 @@ RUN set -eux; \
 	\
 # https://github.com/docker-library/php/issues/443
 	pecl update-channels; \
-	rm -rf /tmp/pear ~/.pearrc
+	rm -rf /tmp/pear
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 


### PR DESCRIPTION
fix "rm -rf /tmp/pear ~/.pearrc' returned a non-zero code: 137"