### PR TITLE
Add "pgp-happy-eyeballs" in Travis to help cut down on gpg-related issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,19 @@ install:
 
 before_script:
   - env | sort
+  - wget -qO- 'https://github.com/tianon/pgp-happy-eyeballs/raw/master/hack-my-builds.sh' | bash
   - cd "$VERSION/$VARIANT"
   - SUBVARIANT="${VARIANT#*/}"
   - image="php:${VERSION}-${SUBVARIANT}-${VARIANT%/*}"
 
 script:
-  - travis_retry docker build -t "$image" .
-  - ~/official-images/test/run.sh "$image"
+  - |
+    (
+      set -Eeuo pipefail
+      set -x
+      docker build -t "$image" .
+      ~/official-images/test/run.sh "$image"
+    )
 
 after_script:
   - docker images

--- a/5.6/alpine3.7/cli/Dockerfile
+++ b/5.6/alpine3.7/cli/Dockerfile
@@ -85,6 +85,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/alpine3.7/fpm/Dockerfile
+++ b/5.6/alpine3.7/fpm/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/alpine3.7/zts/Dockerfile
+++ b/5.6/alpine3.7/zts/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/jessie/apache/Dockerfile
+++ b/5.6/jessie/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/jessie/cli/Dockerfile
+++ b/5.6/jessie/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/jessie/zts/Dockerfile
+++ b/5.6/jessie/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/stretch/apache/Dockerfile
+++ b/5.6/stretch/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/stretch/cli/Dockerfile
+++ b/5.6/stretch/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/stretch/fpm/Dockerfile
+++ b/5.6/stretch/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/5.6/stretch/zts/Dockerfile
+++ b/5.6/stretch/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/alpine3.7/cli/Dockerfile
+++ b/7.0/alpine3.7/cli/Dockerfile
@@ -85,6 +85,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/alpine3.7/fpm/Dockerfile
+++ b/7.0/alpine3.7/fpm/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/alpine3.7/zts/Dockerfile
+++ b/7.0/alpine3.7/zts/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/jessie/apache/Dockerfile
+++ b/7.0/jessie/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/jessie/cli/Dockerfile
+++ b/7.0/jessie/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/jessie/zts/Dockerfile
+++ b/7.0/jessie/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/stretch/apache/Dockerfile
+++ b/7.0/stretch/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/stretch/cli/Dockerfile
+++ b/7.0/stretch/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/stretch/fpm/Dockerfile
+++ b/7.0/stretch/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.0/stretch/zts/Dockerfile
+++ b/7.0/stretch/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/alpine3.7/cli/Dockerfile
+++ b/7.1/alpine3.7/cli/Dockerfile
@@ -85,6 +85,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/alpine3.7/fpm/Dockerfile
+++ b/7.1/alpine3.7/fpm/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/alpine3.7/zts/Dockerfile
+++ b/7.1/alpine3.7/zts/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/stretch/apache/Dockerfile
+++ b/7.1/stretch/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/stretch/cli/Dockerfile
+++ b/7.1/stretch/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/stretch/fpm/Dockerfile
+++ b/7.1/stretch/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.1/stretch/zts/Dockerfile
+++ b/7.1/stretch/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/alpine3.6/cli/Dockerfile
+++ b/7.2/alpine3.6/cli/Dockerfile
@@ -85,6 +85,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/alpine3.6/fpm/Dockerfile
+++ b/7.2/alpine3.6/fpm/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/alpine3.6/zts/Dockerfile
+++ b/7.2/alpine3.6/zts/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/alpine3.7/cli/Dockerfile
+++ b/7.2/alpine3.7/cli/Dockerfile
@@ -85,6 +85,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/alpine3.7/fpm/Dockerfile
+++ b/7.2/alpine3.7/fpm/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/alpine3.7/zts/Dockerfile
+++ b/7.2/alpine3.7/zts/Dockerfile
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -92,6 +92,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -93,6 +93,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -79,6 +79,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -86,6 +86,7 @@ RUN set -xe; \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
+		command -v gpgconf > /dev/null && gpgconf --kill all; \
 		rm -rf "$GNUPGHOME"; \
 	fi; \
 	\


### PR DESCRIPTION
Also, this removes the not-recommended usage of "travis_retry".

(This is a first initial test of the still-new https://github.com/tianon/pgp-happy-eyeballs/blob/master/hack-my-builds.sh to see if it helps enough to be viable everywhere.)