### PR TITLE
Make builds more stable

### DIFF
--- a/7.1/alpine3.7/fpm/Dockerfile
+++ b/7.1/alpine3.7/fpm/Dockerfile
@@ -83,6 +83,8 @@ RUN set -xe; \
 		wget -O php.tar.xz.asc "$PHP_ASC_URL"; \
 		export GNUPGHOME="$(mktemp -d)"; \
 		for key in $GPG_KEYS; do \
+			gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
+			gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
 			gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \


### PR DESCRIPTION
```
+ gpg --keyserver ha.pool.sks-keyservers.net --recv-keys A917B1ECDA84AEC2B568FED6F50ABC807BD5DCD0
gpg: keybox '/tmp/tmp.COnjbo/pubring.kbx' created
gpg: keyserver receive failed: Address not available
```