### PR TITLE
Allow extend build parameters

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,8 @@
 FROM alpine:%%ALPINE_VERSION%%
 
+# Allow extend build parameters
+ARG PHP_EXTRA_CONFIGURE_ARGS
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,5 +1,8 @@
 FROM debian:%%DEBIAN_TAG%%
 
+# Allow extend build parameters
+ARG PHP_EXTRA_CONFIGURE_ARGS
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -169,7 +172,7 @@ RUN set -eux; \
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
 		--with-libdir="lib/$debMultiarch" \
 		\
-		${PHP_EXTRA_CONFIGURE_ARGS:-} \
+		$PHP_EXTRA_CONFIGURE_ARGS \
 	; \
 	make -j "$(nproc)"; \
 	make install; \


### PR DESCRIPTION
This PR allow extend build parameters, for example:
`docker build --build-arg PHP_EXTRA_CONFIGURE_ARGS="xxx yyy" -t zzz .`