### PR TITLE
Remove log decoration from workers output

### DIFF
--- a/7.3-rc/alpine3.8/fpm/Dockerfile
+++ b/7.3-rc/alpine3.8/fpm/Dockerfile
@@ -205,6 +205,7 @@ RUN set -ex \
 		echo; \
 		echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
 		echo 'catch_workers_output = yes'; \
+		echo 'decorate_workers_output = no'; \
 	} | tee php-fpm.d/docker.conf \
 	&& { \
 		echo '[global]'; \

--- a/7.3-rc/stretch/fpm/Dockerfile
+++ b/7.3-rc/stretch/fpm/Dockerfile
@@ -244,6 +244,7 @@ RUN set -ex \
 		echo; \
 		echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
 		echo 'catch_workers_output = yes'; \
+		echo 'decorate_workers_output = no'; \
 	} | tee php-fpm.d/docker.conf \
 	&& { \
 		echo '[global]'; \

--- a/fpm-Dockerfile-block-2
+++ b/fpm-Dockerfile-block-2
@@ -27,6 +27,7 @@ RUN set -ex \
 		echo; \
 		echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
 		echo 'catch_workers_output = yes'; \
+		echo 'decorate_workers_output = no'; \
 	} | tee php-fpm.d/docker.conf \
 	&& { \
 		echo '[global]'; \

--- a/update.sh
+++ b/update.sh
@@ -175,6 +175,10 @@ for version in "${versions[@]}"; do
 				# php 5 still needs older ssl
 				sed -ri 's/libssl-dev/libssl1.0-dev/g' "$version/$suite/$variant/Dockerfile"
 			fi
+			if [ "$variant" = 'fpm' -a "$majorVersion" = '5' ] || [ "$variant" = 'fpm' -a "$majorVersion" = '7' -a "$minorVersion" -lt '3' ]; then
+				# php-fpm "decorate_workers_output" is only available in 7.3+
+				sed -ri '/decorate_workers_output/d' "$version/$suite/$variant/Dockerfile"
+			fi
 
 			# remove any _extra_ blank lines created by the deletions above
 			awk '


### PR DESCRIPTION
As of PHP 7.3 we can finally use STDOUT and STDERR properly in our containers, this disables the `[pool %s] child %d said into %s: \"%s\` format.

More info:

- https://github.com/php/php-src/pull/2458
- https://bugs.php.net/bug.php?id=71880
- https://github.com/docker-library/php/issues/207