### PR TITLE
[TASK] Make Debian based images smaller

### DIFF
--- a/5.6/jessie/apache/Dockerfile
+++ b/5.6/jessie/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/jessie/cli/Dockerfile
+++ b/5.6/jessie/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/jessie/fpm/Dockerfile
+++ b/5.6/jessie/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/jessie/zts/Dockerfile
+++ b/5.6/jessie/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/stretch/apache/Dockerfile
+++ b/5.6/stretch/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/stretch/cli/Dockerfile
+++ b/5.6/stretch/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/stretch/fpm/Dockerfile
+++ b/5.6/stretch/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/5.6/stretch/zts/Dockerfile
+++ b/5.6/stretch/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/jessie/apache/Dockerfile
+++ b/7.0/jessie/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/jessie/cli/Dockerfile
+++ b/7.0/jessie/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/jessie/fpm/Dockerfile
+++ b/7.0/jessie/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/jessie/zts/Dockerfile
+++ b/7.0/jessie/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/stretch/apache/Dockerfile
+++ b/7.0/stretch/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/stretch/cli/Dockerfile
+++ b/7.0/stretch/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/stretch/fpm/Dockerfile
+++ b/7.0/stretch/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.0/stretch/zts/Dockerfile
+++ b/7.0/stretch/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/stretch/apache/Dockerfile
+++ b/7.1/stretch/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/stretch/cli/Dockerfile
+++ b/7.1/stretch/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/stretch/fpm/Dockerfile
+++ b/7.1/stretch/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.1/stretch/zts/Dockerfile
+++ b/7.1/stretch/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsqlite3-dev \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.3-rc/alpine3.8/cli/Dockerfile
+++ b/7.3-rc/alpine3.8/cli/Dockerfile
@@ -56,7 +56,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \

--- a/7.3-rc/alpine3.8/fpm/Dockerfile
+++ b/7.3-rc/alpine3.8/fpm/Dockerfile
@@ -57,7 +57,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \

--- a/7.3-rc/alpine3.8/zts/Dockerfile
+++ b/7.3-rc/alpine3.8/zts/Dockerfile
@@ -57,7 +57,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \

--- a/7.3-rc/stretch/apache/Dockerfile
+++ b/7.3-rc/stretch/apache/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -116,7 +115,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \
@@ -166,6 +165,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.3-rc/stretch/cli/Dockerfile
+++ b/7.3-rc/stretch/cli/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -55,7 +54,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \
@@ -105,6 +104,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.3-rc/stretch/fpm/Dockerfile
+++ b/7.3-rc/stretch/fpm/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -56,7 +55,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/7.3-rc/stretch/zts/Dockerfile
+++ b/7.3-rc/stretch/zts/Dockerfile
@@ -30,7 +30,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -56,7 +55,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.0RC5
-ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz.asc"
+ENV PHP_URL="https://downloads.php.net/~cmb/php-7.3.0RC5.tar.xz" PHP_ASC_URL=""
 ENV PHP_SHA256="0bf6a6bdfd37576b9a341559023b0adf90063b8970ab08ea7a4d8e83b82136cd" PHP_MD5=""
 
 RUN set -xe; \
@@ -106,6 +105,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -24,7 +24,6 @@ ENV PHPIZE_DEPS \
 
 # persistent / runtime deps
 RUN apt-get update && apt-get install -y \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -99,6 +98,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		${PHPIZE_DEPS} \
 		libcurl4-openssl-dev \
 		libedit-dev \
 		libsodium-dev \


### PR DESCRIPTION
Do not permanently install `${PHPIZE_DEPS}` in debian based images, but
install and remove them just around the build process to make images
about 190 MB lighter.