### PR TITLE
[Draft] Add mpm_event / FPM support to apache variant

### DIFF
--- a/apache-Dockerfile-block-1
+++ b/apache-Dockerfile-block-1
@@ -57,4 +57,4 @@ RUN { \
 	&& a2enconf docker-php
 
 ENV PHP_EXTRA_BUILD_DEPS apache2-dev
-ENV PHP_EXTRA_CONFIGURE_ARGS --with-apxs2 --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --with-apxs2 --disable-cgi --enable-fpm --with-fpm-user=www-data --with-fpm-group=www-data

--- a/apache-Dockerfile-block-1
+++ b/apache-Dockerfile-block-1
@@ -44,6 +44,9 @@ RUN a2dismod mpm_event && a2enmod mpm_prefork
 RUN { \
 		echo '<FilesMatch \.php$>'; \
 		echo '\tSetHandler application/x-httpd-php'; \
+		echo '\t<IfDefine FPM>'; \
+		echo '\t\tSetHandler "proxy:unix:/var/run/php-fpm/fpm.sock|fcgi://localhost/"'; \
+		echo '\t</IfDefine>'; \
 		echo '</FilesMatch>'; \
 		echo; \
 		echo 'DirectoryIndex disabled'; \

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -22,9 +22,6 @@ RUN set -ex \
 		echo; echo '; https://github.com/docker-library/php/pull/725#issuecomment-443540114'; echo 'log_limit = 8192'; \
 		echo; \
 		echo '[www]'; \
-		echo '; if we send this to /proc/self/fd/1, it never appears'; \
-		echo 'access.log = /proc/self/fd/2'; \
-		echo; \
 		echo 'clear_env = no'; \
 		echo; \
 		echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
@@ -36,8 +33,27 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
-		echo 'listen = 9000'; \
-	} | tee php-fpm.d/zz-docker.conf
+		echo 'listen = /var/run/php-fpm/fpm.sock'; \
+		echo 'listen.mode = 666'; \
+	} | tee php-fpm.d/zz-docker.conf \
+	&& mkdir -p /var/run/php-fpm && chmod 777 /var/run/php-fpm
+
+# Command that launches Apache and FPM simultaneously
+RUN	{ \
+		echo '#!/bin/bash'; \
+		echo 'if [ -z "$APACHE_KEEP_MODS" ]; then'; \
+		echo '  a2dismod -q mpm_prefork php7 && a2enmod -q mpm_event proxy_fcgi || exit 1'; \
+		echo 'fi'; \
+		echo 'php-fpm $FPM_ARGS &'; \
+		echo 'apache2-foreground -DFPM $APACHE_ARGS &'; \
+		echo; \
+		echo 'trap "stopped=1" TERM INT'; \
+		echo 'wait -n					# wait until container is stopped, or a process exits'; \
+		echo 'kill %1 %2 2> /dev/null			# send sigterm to remaining processes'; \
+		echo 'if [ -z "$stopped" ]; then exit 2; fi	# if it was a crash, container fails immediately'; \
+		echo 'until wait; do true; done			# otherwise, wait for processes to finish'; \
+	} | tee /usr/local/bin/apache-fpm \
+	&& chmod +x /usr/local/bin/apache-fpm
 
 EXPOSE 80
 CMD ["apache2-foreground"]

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -33,6 +33,8 @@ RUN set -ex \
 		echo 'daemonize = no'; \
 		echo; \
 		echo '[www]'; \
+		echo 'user = ${FPM_RUN_USER}'; \
+		echo 'group = ${FPM_RUN_GROUP}'; \
 		echo 'listen = /var/run/php-fpm/fpm.sock'; \
 		echo 'listen.mode = 666'; \
 	} | tee php-fpm.d/zz-docker.conf \

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -1,6 +1,7 @@
 COPY apache2-foreground /usr/local/bin/
 WORKDIR /var/www/html
 
+# Set up FPM
 RUN set -ex \
 	&& cd /usr/local/etc \
 	&& if [ -d php-fpm.d ]; then \

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -1,5 +1,43 @@
 COPY apache2-foreground /usr/local/bin/
 WORKDIR /var/www/html
 
+RUN set -ex \
+	&& cd /usr/local/etc \
+	&& if [ -d php-fpm.d ]; then \
+		# for some reason, upstream's php-fpm.conf.default has "include=NONE/etc/php-fpm.d/*.conf"
+		sed 's!=NONE/!=!g' php-fpm.conf.default | tee php-fpm.conf > /dev/null; \
+		cp php-fpm.d/www.conf.default php-fpm.d/www.conf; \
+	else \
+		# PHP 5.x doesn't use "include=" by default, so we'll create our own simple config that mimics PHP 7+ for consistency
+		mkdir php-fpm.d; \
+		cp php-fpm.conf.default php-fpm.d/www.conf; \
+		{ \
+			echo '[global]'; \
+			echo 'include=etc/php-fpm.d/*.conf'; \
+		} | tee php-fpm.conf; \
+	fi \
+	&& { \
+		echo '[global]'; \
+		echo 'error_log = /proc/self/fd/2'; \
+		echo; echo '; https://github.com/docker-library/php/pull/725#issuecomment-443540114'; echo 'log_limit = 8192'; \
+		echo; \
+		echo '[www]'; \
+		echo '; if we send this to /proc/self/fd/1, it never appears'; \
+		echo 'access.log = /proc/self/fd/2'; \
+		echo; \
+		echo 'clear_env = no'; \
+		echo; \
+		echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
+		echo 'catch_workers_output = yes'; \
+		echo 'decorate_workers_output = no'; \
+	} | tee php-fpm.d/docker.conf \
+	&& { \
+		echo '[global]'; \
+		echo 'daemonize = no'; \
+		echo; \
+		echo '[www]'; \
+		echo 'listen = 9000'; \
+	} | tee php-fpm.d/zz-docker.conf
+
 EXPOSE 80
 CMD ["apache2-foreground"]

--- a/apache-Dockerfile-block-2
+++ b/apache-Dockerfile-block-2
@@ -36,24 +36,12 @@ RUN set -ex \
 		echo 'listen = /var/run/php-fpm/fpm.sock'; \
 		echo 'listen.mode = 666'; \
 	} | tee php-fpm.d/zz-docker.conf \
-	&& mkdir -p /var/run/php-fpm && chmod 777 /var/run/php-fpm
+	&& mkdir -p /var/run/php-fpm \
+	# allow running as an arbitrary user
+	&& chmod 777 /var/run/php-fpm
 
-# Command that launches Apache and FPM simultaneously
-RUN	{ \
-		echo '#!/bin/bash'; \
-		echo 'if [ -z "$APACHE_KEEP_MODS" ]; then'; \
-		echo '  a2dismod -q mpm_prefork php7 && a2enmod -q mpm_event proxy_fcgi || exit 1'; \
-		echo 'fi'; \
-		echo 'php-fpm $FPM_ARGS &'; \
-		echo 'apache2-foreground -DFPM $APACHE_ARGS &'; \
-		echo; \
-		echo 'trap "stopped=1" TERM INT'; \
-		echo 'wait -n					# wait until container is stopped, or a process exits'; \
-		echo 'kill %1 %2 2> /dev/null			# send sigterm to remaining processes'; \
-		echo 'if [ -z "$stopped" ]; then exit 2; fi	# if it was a crash, container fails immediately'; \
-		echo 'until wait; do true; done			# otherwise, wait for processes to finish'; \
-	} | tee /usr/local/bin/apache-fpm \
-	&& chmod +x /usr/local/bin/apache-fpm
+# Provide alternate command to start Apache with FPM
+COPY apache-fpm /usr/local/bin/
 
 EXPOSE 80
 CMD ["apache2-foreground"]

--- a/apache-fpm
+++ b/apache-fpm
@@ -1,4 +1,16 @@
 #!/bin/bash
+
+# By default, FPM will run as the same user as Apache
+. "$APACHE_ENVVARS"
+: ${FPM_RUN_USER:=$APACHE_RUN_USER}
+: ${FPM_RUN_GROUP:=$APACHE_RUN_GROUP}
+export FPM_RUN_USER FPM_RUN_GROUP
+
+# Strip off any '#' symbol ('#1000' is valid syntax for Apache)
+pound='#'
+FPM_RUN_USER="${FPM_RUN_USER#$pound}"
+FPM_RUN_GROUP="${FPM_RUN_GROUP#$pound}"
+
 if [ -z "$APACHE_KEEP_MODS" ]; then
 	a2dismod -q mpm_prefork php7 && a2enmod -q mpm_event proxy_fcgi || exit 1
 fi

--- a/apache-fpm
+++ b/apache-fpm
@@ -1,0 +1,12 @@
+#!/bin/bash
+if [ -z "$APACHE_KEEP_MODS" ]; then
+	a2dismod -q mpm_prefork php7 && a2enmod -q mpm_event proxy_fcgi || exit 1
+fi
+php-fpm $FPM_ARGS &
+apache2-foreground -DFPM $APACHE_ARGS &
+
+trap "stopped=1" TERM INT
+wait -n					# wait until container is stopped, or a process exits
+kill %1 %2 2> /dev/null			# send sigterm to remaining processes
+if [ -z "$stopped" ]; then exit 2; fi	# if it was a crash, container fails immediately
+until wait; do true; done		# otherwise, wait for processes to finish

--- a/apache-fpm
+++ b/apache-fpm
@@ -11,14 +11,20 @@ pound='#'
 FPM_RUN_USER="${FPM_RUN_USER#$pound}"
 FPM_RUN_GROUP="${FPM_RUN_GROUP#$pound}"
 
+# Setup Apache modules and launch!
 if [ -z "$APACHE_KEEP_MODS" ]; then
 	a2dismod -q mpm_prefork php7 && a2enmod -q mpm_event proxy_fcgi || exit 1
 fi
 php-fpm $FPM_ARGS &
 apache2-foreground -DFPM "$@" &
 
+# Wait until container is stopped, or a process crashes
 trap "stopped=1" TERM INT
-wait -n					# wait until container is stopped, or a process exits
-kill %1 %2 2> /dev/null			# send sigterm to remaining processes
-if [ -z "$stopped" ]; then exit 2; fi	# if it was a crash, container fails immediately
-until wait; do true; done		# otherwise, wait for processes to finish
+wait -n
+
+# Tell processes to terminate
+kill %1 %2 2> /dev/null
+# If there was a crash, container fails immediately
+if [ -z "$stopped" ]; then exit 2; fi
+# If the container was stopped, wait for processes to finish
+until wait; do true; done

--- a/apache-fpm
+++ b/apache-fpm
@@ -15,7 +15,7 @@ if [ -z "$APACHE_KEEP_MODS" ]; then
 	a2dismod -q mpm_prefork php7 && a2enmod -q mpm_event proxy_fcgi || exit 1
 fi
 php-fpm $FPM_ARGS &
-apache2-foreground -DFPM $APACHE_ARGS &
+apache2-foreground -DFPM "$@" &
 
 trap "stopped=1" TERM INT
 wait -n					# wait until container is stopped, or a process exits

--- a/update.sh
+++ b/update.sh
@@ -159,7 +159,7 @@ for version in "${versions[@]}"; do
 				# sodium is part of php core 7.2+ https://wiki.php.net/rfc/libsodium
 				sed -ri '/sodium/d' "$version/$suite/$variant/Dockerfile"
 			fi
-			if [ "$variant" = 'fpm' -a "$majorVersion" = '7' -a "$minorVersion" -lt '3' ]; then
+			if [ "$variant" = 'fpm' -o "$variant" = 'apache' ] && [ "$majorVersion" = '7' -a "$minorVersion" -lt '3' ]; then
 				# php-fpm "decorate_workers_output" is only available in 7.3+
 				sed -ri \
 					-e '/decorate_workers_output/d' \

--- a/update.sh
+++ b/update.sh
@@ -146,7 +146,7 @@ for version in "${versions[@]}"; do
 				docker-php-source \
 				"$version/$suite/$variant/"
 			if [ "$variant" = 'apache' ]; then
-				cp -a apache2-foreground "$version/$suite/$variant/"
+				cp -a apache2-foreground apache-fpm "$version/$suite/$variant/"
 			fi
 			if [ "$majorVersion" = '7' -a "$minorVersion" -lt '2' ] || [ "$suite" = 'jessie' ]; then
 				# argon2 password hashing is only supported in 7.2+ and stretch+ / alpine 3.8+


### PR DESCRIPTION
On `apache` images, this adds an `apache-fpm` command that starts Apache + FPM simultaneously (taking care of switching to mpm_event + proxy_fcgi). As said in #742, this is the upstream recommended setup.

To switch to this setup, all users have to do is `CMD ["apache-fpm"]` in their Dockerfile.

### Implementation

The first commit just copies build flags and configuration code from `fpm` variant.
The second commit adds `apache-fpm`. Things to note:

 - FPM listens on a UNIX socket, not TCP as in original variant. This improves performance.
 - `access_log` is disabled by default on FPM to reduce log spam (only Apache access log is shown).
 - [runit](http://smarden.org/runit) is used to run both processes simultaneously. It's far lightweight and simple to setup than i.e. supervisord, and only consumes ~1MB of RAM in my tests. It's used in phusion-baseimage as well.
 - `apache-fpm` disables `mpm_prefork` + `php` and enables `mpm_event` + `proxy_fcgi` before starting everything. This can be disabled with environment variable `APACHE_KEEP_MODS` if the user needs absolute freedom over loaded modules.
