### PR TITLE
remove extensions/*.a

### DIFF
--- a/7.1/alpine3.8/cli/Dockerfile
+++ b/7.1/alpine3.8/cli/Dockerfile
@@ -144,6 +144,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/alpine3.8/fpm/Dockerfile
+++ b/7.1/alpine3.8/fpm/Dockerfile
@@ -145,6 +145,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/alpine3.8/zts/Dockerfile
+++ b/7.1/alpine3.8/zts/Dockerfile
@@ -145,6 +145,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/alpine3.9/cli/Dockerfile
+++ b/7.1/alpine3.9/cli/Dockerfile
@@ -144,6 +144,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/alpine3.9/fpm/Dockerfile
+++ b/7.1/alpine3.9/fpm/Dockerfile
@@ -145,6 +145,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/alpine3.9/zts/Dockerfile
+++ b/7.1/alpine3.9/zts/Dockerfile
@@ -145,6 +145,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.1/jessie/apache/Dockerfile
+++ b/7.1/jessie/apache/Dockerfile
@@ -225,6 +225,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/jessie/cli/Dockerfile
+++ b/7.1/jessie/cli/Dockerfile
@@ -165,6 +165,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/jessie/fpm/Dockerfile
+++ b/7.1/jessie/fpm/Dockerfile
@@ -166,6 +166,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/jessie/zts/Dockerfile
+++ b/7.1/jessie/zts/Dockerfile
@@ -166,6 +166,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/stretch/apache/Dockerfile
+++ b/7.1/stretch/apache/Dockerfile
@@ -225,6 +225,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/stretch/cli/Dockerfile
+++ b/7.1/stretch/cli/Dockerfile
@@ -165,6 +165,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/stretch/fpm/Dockerfile
+++ b/7.1/stretch/fpm/Dockerfile
@@ -166,6 +166,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.1/stretch/zts/Dockerfile
+++ b/7.1/stretch/zts/Dockerfile
@@ -166,6 +166,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.2/alpine3.8/cli/Dockerfile
+++ b/7.2/alpine3.8/cli/Dockerfile
@@ -150,6 +150,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.2/alpine3.8/fpm/Dockerfile
+++ b/7.2/alpine3.8/fpm/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.2/alpine3.8/zts/Dockerfile
+++ b/7.2/alpine3.8/zts/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.2/alpine3.9/cli/Dockerfile
+++ b/7.2/alpine3.9/cli/Dockerfile
@@ -150,6 +150,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.2/alpine3.9/fpm/Dockerfile
+++ b/7.2/alpine3.9/fpm/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.2/alpine3.9/zts/Dockerfile
+++ b/7.2/alpine3.9/zts/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -244,6 +244,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -184,6 +184,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -185,6 +185,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -185,6 +185,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.3/alpine3.8/cli/Dockerfile
+++ b/7.3/alpine3.8/cli/Dockerfile
@@ -150,6 +150,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.3/alpine3.8/fpm/Dockerfile
+++ b/7.3/alpine3.8/fpm/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.3/alpine3.8/zts/Dockerfile
+++ b/7.3/alpine3.8/zts/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.3/alpine3.9/cli/Dockerfile
+++ b/7.3/alpine3.9/cli/Dockerfile
@@ -150,10 +150,9 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
-		&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
-	&& find "$(php -r 'echo ini_get("extension_dir");')" -type f -name '*.a' -delete
 	&& make clean \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.3/alpine3.9/cli/Dockerfile
+++ b/7.3/alpine3.9/cli/Dockerfile
@@ -152,6 +152,8 @@ RUN set -xe \
 	&& make -j "$(nproc)" \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
+		&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
+	&& find "$(php -r 'echo ini_get("extension_dir");')" -type f -name '*.a' -delete
 	&& make clean \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.3/alpine3.9/fpm/Dockerfile
+++ b/7.3/alpine3.9/fpm/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.3/alpine3.9/zts/Dockerfile
+++ b/7.3/alpine3.9/zts/Dockerfile
@@ -151,6 +151,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/7.3/stretch/apache/Dockerfile
+++ b/7.3/stretch/apache/Dockerfile
@@ -244,6 +244,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.3/stretch/cli/Dockerfile
+++ b/7.3/stretch/cli/Dockerfile
@@ -184,6 +184,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.3/stretch/fpm/Dockerfile
+++ b/7.3/stretch/fpm/Dockerfile
@@ -185,6 +185,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/7.3/stretch/zts/Dockerfile
+++ b/7.3/stretch/zts/Dockerfile
@@ -185,6 +185,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -144,6 +144,7 @@ RUN set -xe \
 		\
 		$PHP_EXTRA_CONFIGURE_ARGS \
 	&& make -j "$(nproc)" \
+	&& find -type f -name '*.a' -delete \
 	&& make install \
 	&& { find /usr/local/bin /usr/local/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; } \
 	&& make clean \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -178,6 +178,7 @@ RUN set -eux; \
 		${PHP_EXTRA_CONFIGURE_ARGS:-} \
 	; \
 	make -j "$(nproc)"; \
+	find -type f -name '*.a' -delete; \
 	make install; \
 	find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
 	make clean; \


### PR DESCRIPTION
remove extensions/*.a: the .a are build artifact from libtool; these are not used in any way.

these are present (at least in alpine) image:
```
/usr/local/lib/php/extensions/no-debug-non-zts-20180731 # ls -l *.a
-rwxr-xr-x    1 root     root        856274 Feb  9 02:05 opcache.a
-rwxr-xr-x    1 root     root        132598 Feb  9 02:05 sodium.a
```