### PR TITLE
Sets PHP error level for getting extension dir

### DIFF
--- a/7.1/alpine3.8/cli/docker-php-ext-enable
+++ b/7.1/alpine3.8/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/alpine3.8/fpm/docker-php-ext-enable
+++ b/7.1/alpine3.8/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/alpine3.8/zts/docker-php-ext-enable
+++ b/7.1/alpine3.8/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/alpine3.9/cli/docker-php-ext-enable
+++ b/7.1/alpine3.9/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/alpine3.9/fpm/docker-php-ext-enable
+++ b/7.1/alpine3.9/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/alpine3.9/zts/docker-php-ext-enable
+++ b/7.1/alpine3.9/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/jessie/apache/docker-php-ext-enable
+++ b/7.1/jessie/apache/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/jessie/cli/docker-php-ext-enable
+++ b/7.1/jessie/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/jessie/fpm/docker-php-ext-enable
+++ b/7.1/jessie/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/jessie/zts/docker-php-ext-enable
+++ b/7.1/jessie/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/stretch/apache/docker-php-ext-enable
+++ b/7.1/stretch/apache/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/stretch/cli/docker-php-ext-enable
+++ b/7.1/stretch/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/stretch/fpm/docker-php-ext-enable
+++ b/7.1/stretch/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.1/stretch/zts/docker-php-ext-enable
+++ b/7.1/stretch/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/alpine3.8/cli/docker-php-ext-enable
+++ b/7.2/alpine3.8/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/alpine3.8/fpm/docker-php-ext-enable
+++ b/7.2/alpine3.8/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/alpine3.8/zts/docker-php-ext-enable
+++ b/7.2/alpine3.8/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/alpine3.9/cli/docker-php-ext-enable
+++ b/7.2/alpine3.9/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/alpine3.9/fpm/docker-php-ext-enable
+++ b/7.2/alpine3.9/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/alpine3.9/zts/docker-php-ext-enable
+++ b/7.2/alpine3.9/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/stretch/apache/docker-php-ext-enable
+++ b/7.2/stretch/apache/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/stretch/cli/docker-php-ext-enable
+++ b/7.2/stretch/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/stretch/fpm/docker-php-ext-enable
+++ b/7.2/stretch/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.2/stretch/zts/docker-php-ext-enable
+++ b/7.2/stretch/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/alpine3.8/cli/docker-php-ext-enable
+++ b/7.3/alpine3.8/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/alpine3.8/fpm/docker-php-ext-enable
+++ b/7.3/alpine3.8/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/alpine3.8/zts/docker-php-ext-enable
+++ b/7.3/alpine3.8/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/alpine3.9/cli/docker-php-ext-enable
+++ b/7.3/alpine3.9/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/alpine3.9/fpm/docker-php-ext-enable
+++ b/7.3/alpine3.9/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/alpine3.9/zts/docker-php-ext-enable
+++ b/7.3/alpine3.9/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/stretch/apache/docker-php-ext-enable
+++ b/7.3/stretch/apache/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/stretch/cli/docker-php-ext-enable
+++ b/7.3/stretch/cli/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/stretch/fpm/docker-php-ext-enable
+++ b/7.3/stretch/fpm/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/7.3/stretch/zts/docker-php-ext-enable
+++ b/7.3/stretch/zts/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'error_reporting=' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-extDir="$(php -d 'error_reporting=' -r 'echo ini_get("extension_dir");')"
+extDir="$(php -d 'display_errors=stderr' -r 'echo ini_get("extension_dir");')"
 cd "$extDir"
 
 usage() {
@@ -94,7 +94,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2


### PR DESCRIPTION
If an uncaught exception is thrown during parsing of the php.ini file, `$extDir` will contain a combination of the exception and the path.  This script shouldn't care about error messages though as long as it gets the path.  This updates the script so that php won't emit any error messages.