### PR TITLE
Add docker-php-ext-get

### DIFF
--- a/7.4-rc/alpine3.9/cli/docker-php-ext-get
+++ b/7.4-rc/alpine3.9/cli/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/7.4-rc/alpine3.9/fpm/docker-php-ext-get
+++ b/7.4-rc/alpine3.9/fpm/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/7.4-rc/alpine3.9/zts/docker-php-ext-get
+++ b/7.4-rc/alpine3.9/zts/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/7.4-rc/stretch/apache/docker-php-ext-get
+++ b/7.4-rc/stretch/apache/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/7.4-rc/stretch/cli/docker-php-ext-get
+++ b/7.4-rc/stretch/cli/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/7.4-rc/stretch/fpm/docker-php-ext-get
+++ b/7.4-rc/stretch/fpm/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/7.4-rc/stretch/zts/docker-php-ext-get
+++ b/7.4-rc/stretch/zts/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1

--- a/docker-php-ext-get
+++ b/docker-php-ext-get
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+set -e
+
+dir=/usr/src/php
+
+if [ ! -f "$dir/.docker-extracted" ]; then
+    echo >&2 "error: PHP source required, run 'docker-php-source extract' first"
+    exit 1
+fi
+
+dir="$dir/ext"
+
+usage() {
+	echo "usage: $0 module-name module-version"
+	echo "   ie: $0 redis 4.3.0"
+}
+
+name=$1
+version=$2
+
+if [ -z "$name" ]; then
+	usage >&2
+	exit 1
+fi
+
+if [ -z "$version" ]; then
+	usage >&2
+	exit 1
+fi
+
+mkdir -p "$dir/$name"
+curl -fsSL "https://pecl.php.net/get/$name-$version.tgz" | tar xvz -C "$dir/$name" --strip 1


### PR DESCRIPTION
Hi!,

Starting with PHP 7.4 PEAR is no longer included and the PECL command is no longer available, which means we no longer have an easy way to install PHP extensions. I looked for solutions and came up with this `docker-php-ext-get` script. [I wrote an article about it](https://olvlvl.com/2019-06-docker-pecl-without-pecl).

Basically, with the script included in the Docker image, installing `mongodb` v1.5.2 would look something like this:

```dockerfile
FROM php:7.4.0alpha1-fpm-stretch

RUN docker-php-source extract &&\
    docker-php-ext-get mongodb 1.5.2 &&\
    docker-php-ext-install mongodb &&\
    docker-php-source delete
```

Installing `igbinary` with `redis` would look like this:

```dockerfile
FROM php:7.4.0alpha1-fpm-stretch

RUN docker-php-source extract &&\
    docker-php-ext-get igbinary 3.0.1 &&\
    docker-php-ext-get redis 4.3.0 &&\
    docker-php-ext-configure redis --enable-redis-igbinary &&\
    docker-php-ext-install igbinary redis &&\
    docker-php-source delete
```

Wdyt?