### PR TITLE
Remove the Alpine argon2 library fix

### DIFF
--- a/7.4-rc/alpine3.10/cli/Dockerfile
+++ b/7.4-rc/alpine3.10/cli/Dockerfile
@@ -113,9 +113,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/7.4-rc/alpine3.10/fpm/Dockerfile
+++ b/7.4-rc/alpine3.10/fpm/Dockerfile
@@ -114,9 +114,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/7.4-rc/alpine3.10/zts/Dockerfile
+++ b/7.4-rc/alpine3.10/zts/Dockerfile
@@ -114,9 +114,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/7.4-rc/alpine3.9/cli/Dockerfile
+++ b/7.4-rc/alpine3.9/cli/Dockerfile
@@ -113,9 +113,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/7.4-rc/alpine3.9/fpm/Dockerfile
+++ b/7.4-rc/alpine3.9/fpm/Dockerfile
@@ -114,9 +114,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/7.4-rc/alpine3.9/zts/Dockerfile
+++ b/7.4-rc/alpine3.9/zts/Dockerfile
@@ -114,9 +114,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -107,9 +107,6 @@ RUN set -eux; \
 	export CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-		# fix ARGON2 detection for 7.4-alpha1 https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
-		ARGON2_LIBS="-largon2" \
-		ARGON2_CFLAGS="-I/usr/include" \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/update.sh
+++ b/update.sh
@@ -162,10 +162,8 @@ for version in "${versions[@]}"; do
 			fi
 			if [ "$majorVersion" = '7' -a "$minorVersion" -lt '4' ]; then
 				# oniguruma is part of mbstring in php 7.4+
-				# ARGON2 is a hack only required for alpha1: https://github.com/docker-library/php/pull/840#pullrequestreview-249660894
 				sed -ri \
 					-e '/oniguruma-dev|libonig-dev/d' \
-					-e '/ARGON2/d' \
 					"$version/$suite/$variant/Dockerfile"
 			else
 				# 7.4 and above no longer include pecl/pear: https://github.com/php/php-src/pull/3781


### PR DESCRIPTION
hello, the fix has been patched upstream in Alpine v3.9 and v3.10 and upcoming PHP 7.4.0alpha2.

Thanks.