### PR TITLE
Add "--with-pear" in 7.4

### DIFF
--- a/7.4-rc/alpine3.10/cli/Dockerfile
+++ b/7.4-rc/alpine3.10/cli/Dockerfile
@@ -144,6 +144,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -172,6 +175,9 @@ RUN set -eux; \
 	\
 	apk del --no-network .build-deps; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/alpine3.10/fpm/Dockerfile
+++ b/7.4-rc/alpine3.10/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -173,6 +176,9 @@ RUN set -eux; \
 	\
 	apk del --no-network .build-deps; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/alpine3.10/zts/Dockerfile
+++ b/7.4-rc/alpine3.10/zts/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -173,6 +176,9 @@ RUN set -eux; \
 	\
 	apk del --no-network .build-deps; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/alpine3.9/cli/Dockerfile
+++ b/7.4-rc/alpine3.9/cli/Dockerfile
@@ -144,6 +144,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -172,6 +175,9 @@ RUN set -eux; \
 	\
 	apk del --no-network .build-deps; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/alpine3.9/fpm/Dockerfile
+++ b/7.4-rc/alpine3.9/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -173,6 +176,9 @@ RUN set -eux; \
 	\
 	apk del --no-network .build-deps; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/alpine3.9/zts/Dockerfile
+++ b/7.4-rc/alpine3.9/zts/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -173,6 +176,9 @@ RUN set -eux; \
 	\
 	apk del --no-network .build-deps; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/stretch/apache/Dockerfile
+++ b/7.4-rc/stretch/apache/Dockerfile
@@ -234,6 +234,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -266,6 +269,9 @@ RUN set -eux; \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/stretch/cli/Dockerfile
+++ b/7.4-rc/stretch/cli/Dockerfile
@@ -174,6 +174,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -206,6 +209,9 @@ RUN set -eux; \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/stretch/fpm/Dockerfile
+++ b/7.4-rc/stretch/fpm/Dockerfile
@@ -175,6 +175,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -207,6 +210,9 @@ RUN set -eux; \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/7.4-rc/stretch/zts/Dockerfile
+++ b/7.4-rc/stretch/zts/Dockerfile
@@ -175,6 +175,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \
@@ -207,6 +210,9 @@ RUN set -eux; \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	\
+# update pecl channel definitions https://github.com/docker-library/php/issues/443
+	pecl update-channels; \
+	rm -rf /tmp/pear ~/.pearrc; \
 # smoke test
 	php --version
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -138,6 +138,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -168,6 +168,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear") and will be removed in PHP 8+; see also https://github.com/docker-library/php/issues/846#issuecomment-505638494
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \


### PR DESCRIPTION
This means that `pear` and `pecl` will be available for PHP 7.4+, but *will be removed* in PHP 8+ (see https://externals.io/message/103977 for upstream discussion around this deprecation).

I tested the 8+ changes to this script by creating a few fake "8.0" bits in the script itself (fake `possibles` version, etc) and verified that the result is as expected.

Closes #846