### PR TITLE
fix: trash PHP sources after build to reduce image size

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -205,6 +205,7 @@ RUN set -eux; \
 # update pecl channel definitions https://github.com/docker-library/php/issues/443
 	pecl update-channels; \
 	rm -rf /tmp/pear ~/.pearrc; \
+	rm -rf /usr/src/* /var/cache/debconf; \
 # smoke test
 	php --version
 


### PR DESCRIPTION
Hi there,

Since two minor versions I have the impression that the PHP image based on Debian has taken a little weight (~ 20MB wasted space) ...

I looked in the layers of the images with `dive` (https://github.com/wagoodman/dive) and noticed that PHP sources are no longer purged at the end of the build.

`dive php:7.2.22-fpm-buster`

<img width="1440" alt="Screen Shot 2019-09-05 at 11 04 16 AM" src="https://user-images.githubusercontent.com/245284/64328103-2a833d00-cfcd-11e9-8db8-1e91723ff59b.png">

`dive php:7.2.20-fpm-buster`

<img width="1440" alt="Screen Shot 2019-09-05 at 11 08 12 AM" src="https://user-images.githubusercontent.com/245284/64328335-8bab1080-cfcd-11e9-878b-cbd78d5d3010.png">

You will find a potential fix attached to this PR (on the other hand I have not yet been able to test it thoroughly).

Thank you.