### PR TITLE
[security] Update to 7.3.10

### DIFF
--- a/7.2/alpine3.10/cli/Dockerfile
+++ b/7.2/alpine3.10/cli/Dockerfile
@@ -61,9 +61,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/alpine3.10/fpm/Dockerfile
+++ b/7.2/alpine3.10/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/alpine3.10/zts/Dockerfile
+++ b/7.2/alpine3.10/zts/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/alpine3.9/cli/Dockerfile
+++ b/7.2/alpine3.9/cli/Dockerfile
@@ -61,9 +61,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/alpine3.9/fpm/Dockerfile
+++ b/7.2/alpine3.9/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/alpine3.9/zts/Dockerfile
+++ b/7.2/alpine3.9/zts/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/buster/apache/Dockerfile
+++ b/7.2/buster/apache/Dockerfile
@@ -123,9 +123,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/buster/cli/Dockerfile
+++ b/7.2/buster/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/buster/fpm/Dockerfile
+++ b/7.2/buster/fpm/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/buster/zts/Dockerfile
+++ b/7.2/buster/zts/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -123,9 +123,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
-ENV PHP_VERSION 7.2.22
-ENV PHP_URL="https://www.php.net/get/php-7.2.22.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.22.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="eb597fcf8dc0a6211a42a6346de4f63ee166829a6df6d8ed767fe14be8d1c3a3" PHP_MD5=""
+ENV PHP_VERSION 7.2.23
+ENV PHP_URL="https://www.php.net/get/php-7.2.23.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.23.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="74e045ec8ff26290db6a3688826dcdf43b87bc509e508e9cb76dab742804ca14" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/alpine3.10/cli/Dockerfile
+++ b/7.3/alpine3.10/cli/Dockerfile
@@ -61,9 +61,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/alpine3.10/fpm/Dockerfile
+++ b/7.3/alpine3.10/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/alpine3.10/zts/Dockerfile
+++ b/7.3/alpine3.10/zts/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/alpine3.9/cli/Dockerfile
+++ b/7.3/alpine3.9/cli/Dockerfile
@@ -61,9 +61,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/alpine3.9/fpm/Dockerfile
+++ b/7.3/alpine3.9/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/alpine3.9/zts/Dockerfile
+++ b/7.3/alpine3.9/zts/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/buster/apache/Dockerfile
+++ b/7.3/buster/apache/Dockerfile
@@ -123,9 +123,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/buster/cli/Dockerfile
+++ b/7.3/buster/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/buster/fpm/Dockerfile
+++ b/7.3/buster/fpm/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/buster/zts/Dockerfile
+++ b/7.3/buster/zts/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/stretch/apache/Dockerfile
+++ b/7.3/stretch/apache/Dockerfile
@@ -123,9 +123,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/stretch/cli/Dockerfile
+++ b/7.3/stretch/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/stretch/fpm/Dockerfile
+++ b/7.3/stretch/fpm/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/7.3/stretch/zts/Dockerfile
+++ b/7.3/stretch/zts/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
 
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
-ENV PHP_VERSION 7.3.9
-ENV PHP_URL="https://www.php.net/get/php-7.3.9.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.9.tar.xz.asc/from/this/mirror"
-ENV PHP_SHA256="4007f24a39822bef2805b75c625551d30be9eeed329d52eb0838fa5c1b91c1fd" PHP_MD5=""
+ENV PHP_VERSION 7.3.10
+ENV PHP_URL="https://www.php.net/get/php-7.3.10.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.10.tar.xz.asc/from/this/mirror"
+ENV PHP_SHA256="42f00a15419e05771734b7159c8d39d639b8a5a6770413adfa2615f6f923d906" PHP_MD5=""
 
 RUN set -eux; \
 	\


### PR DESCRIPTION
Making this PR manually given that 7.4.0RC2 is gumming up our builder ATM (https://github.com/docker-library/php/issues/882#issuecomment-533305377).

I believe there's at least going to be a 7.2 release as well (from commits/tags on https://github.com/php/php-src), but it doesn't appear to be available yet.