### PR TITLE
Prevent "silent" failures by having docker-php-ext-configure error on unknown flags so users have to fix them

### DIFF
--- a/7.2/alpine3.10/cli/docker-php-ext-configure
+++ b/7.2/alpine3.10/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/alpine3.10/fpm/docker-php-ext-configure
+++ b/7.2/alpine3.10/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/alpine3.10/zts/docker-php-ext-configure
+++ b/7.2/alpine3.10/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/alpine3.9/cli/docker-php-ext-configure
+++ b/7.2/alpine3.9/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/alpine3.9/fpm/docker-php-ext-configure
+++ b/7.2/alpine3.9/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/alpine3.9/zts/docker-php-ext-configure
+++ b/7.2/alpine3.9/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/buster/apache/docker-php-ext-configure
+++ b/7.2/buster/apache/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/buster/cli/docker-php-ext-configure
+++ b/7.2/buster/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/buster/fpm/docker-php-ext-configure
+++ b/7.2/buster/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/buster/zts/docker-php-ext-configure
+++ b/7.2/buster/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/stretch/apache/docker-php-ext-configure
+++ b/7.2/stretch/apache/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/stretch/cli/docker-php-ext-configure
+++ b/7.2/stretch/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/stretch/fpm/docker-php-ext-configure
+++ b/7.2/stretch/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.2/stretch/zts/docker-php-ext-configure
+++ b/7.2/stretch/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/alpine3.10/cli/docker-php-ext-configure
+++ b/7.3/alpine3.10/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/alpine3.10/fpm/docker-php-ext-configure
+++ b/7.3/alpine3.10/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/alpine3.10/zts/docker-php-ext-configure
+++ b/7.3/alpine3.10/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/alpine3.9/cli/docker-php-ext-configure
+++ b/7.3/alpine3.9/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/alpine3.9/fpm/docker-php-ext-configure
+++ b/7.3/alpine3.9/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/alpine3.9/zts/docker-php-ext-configure
+++ b/7.3/alpine3.9/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/buster/apache/docker-php-ext-configure
+++ b/7.3/buster/apache/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/buster/cli/docker-php-ext-configure
+++ b/7.3/buster/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/buster/fpm/docker-php-ext-configure
+++ b/7.3/buster/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/buster/zts/docker-php-ext-configure
+++ b/7.3/buster/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/stretch/apache/docker-php-ext-configure
+++ b/7.3/stretch/apache/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/stretch/cli/docker-php-ext-configure
+++ b/7.3/stretch/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/stretch/fpm/docker-php-ext-configure
+++ b/7.3/stretch/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.3/stretch/zts/docker-php-ext-configure
+++ b/7.3/stretch/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/alpine3.10/cli/docker-php-ext-configure
+++ b/7.4/alpine3.10/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/alpine3.10/fpm/docker-php-ext-configure
+++ b/7.4/alpine3.10/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/alpine3.10/zts/docker-php-ext-configure
+++ b/7.4/alpine3.10/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/buster/apache/docker-php-ext-configure
+++ b/7.4/buster/apache/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/buster/cli/docker-php-ext-configure
+++ b/7.4/buster/cli/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/buster/fpm/docker-php-ext-configure
+++ b/7.4/buster/fpm/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/7.4/buster/zts/docker-php-ext-configure
+++ b/7.4/buster/zts/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"

--- a/docker-php-ext-configure
+++ b/docker-php-ext-configure
@@ -66,4 +66,4 @@ fi
 
 cd "$ext"
 phpize
-./configure "$@"
+./configure --enable-option-checking=fatal "$@"


### PR DESCRIPTION
`configure: WARNING: unrecognized options` just gets lost in all the configure output

Fixes #917

Users can go back to warn only with `--enable-option-checking` ([gnu autoconf manual](https://www.gnu.org/software/autoconf/manual/autoconf-2.62/autoconf.html#Option-Checking)):

```console
$ docker-php-ext-configure gd --enable-option-checking --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/
```