### PR TITLE
Set gecos field on Alpine to match Debian

### DIFF
--- a/7.2/alpine3.10/cli/Dockerfile
+++ b/7.2/alpine3.10/cli/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.2/alpine3.10/fpm/Dockerfile
+++ b/7.2/alpine3.10/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.2/alpine3.10/zts/Dockerfile
+++ b/7.2/alpine3.10/zts/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.2/alpine3.11/cli/Dockerfile
+++ b/7.2/alpine3.11/cli/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.2/alpine3.11/fpm/Dockerfile
+++ b/7.2/alpine3.11/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.2/alpine3.11/zts/Dockerfile
+++ b/7.2/alpine3.11/zts/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.3/alpine3.10/cli/Dockerfile
+++ b/7.3/alpine3.10/cli/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.3/alpine3.10/fpm/Dockerfile
+++ b/7.3/alpine3.10/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.3/alpine3.10/zts/Dockerfile
+++ b/7.3/alpine3.10/zts/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.3/alpine3.11/cli/Dockerfile
+++ b/7.3/alpine3.11/cli/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.3/alpine3.11/fpm/Dockerfile
+++ b/7.3/alpine3.11/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.3/alpine3.11/zts/Dockerfile
+++ b/7.3/alpine3.11/zts/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.4/alpine3.10/cli/Dockerfile
+++ b/7.4/alpine3.10/cli/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.4/alpine3.10/fpm/Dockerfile
+++ b/7.4/alpine3.10/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.4/alpine3.10/zts/Dockerfile
+++ b/7.4/alpine3.10/zts/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.4/alpine3.11/cli/Dockerfile
+++ b/7.4/alpine3.11/cli/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.4/alpine3.11/fpm/Dockerfile
+++ b/7.4/alpine3.11/fpm/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/7.4/alpine3.11/zts/Dockerfile
+++ b/7.4/alpine3.11/zts/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -25,7 +25,7 @@ RUN apk add --no-cache \
 # ensure www-data user exists
 RUN set -eux; \
 	addgroup -g 82 -S www-data; \
-	adduser -u 82 -D -S -G www-data www-data
+	adduser -u 82 -D -S -G www-data -g www-data www-data
 # 82 is the standard uid/gid for "www-data" in Alpine
 # https://git.alpinelinux.org/aports/tree/main/apache2/apache2.pre-install?h=3.9-stable
 # https://git.alpinelinux.org/aports/tree/main/lighttpd/lighttpd.pre-install?h=3.9-stable


### PR DESCRIPTION
Otherwise busybox's `adduser` uses `Linux User,,,`

```console
$ docker run -it --rm php:7.3-fpm-alpine grep www-data /etc/passwd
www-data:x:82:82:Linux User,,,:/home/www-data:/sbin/nologin
$ docker run -it --rm php:7.3-fpm-stretch grep www-data /etc/passwd
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin

$ # new image
$ docker run -it --rm php:7.3-alpine-test grep www-data /etc/passwd
www-data:x:82:82:www-data:/home/www-data:/sbin/nologin
```

Since this is non-critical and will break most of the Docker build cache, we should wait to merge until the next version bump or Debian rebuild to minimize rebuilds (or at least delay the PR to official-images)