### PR TITLE
Add alpine pkg "tzdata" to alpine Dockerfile template

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -104,6 +104,7 @@ RUN set -eux; \
 		oniguruma-dev \
 		openssl-dev \
 		sqlite-dev \
+		tzdata \
 	; \
 	\
 	export CFLAGS="$PHP_CFLAGS" \


### PR DESCRIPTION
With the package "tzdata" installed on the alpine image it's easily possible to set the container's timezone by setting TZ environment variable (e.g. TZ=Europe/Zurich).