### PR TITLE
Fixing parentRepoToArches global variable issue

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -52,7 +52,8 @@ getArches() {
 	local repo="$1"; shift
 	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
 
-	eval "declare -g -A parentRepoToArches=( $(
+	eval "declare -g -A parentRepoToArches"
+	eval "parentRepoToArches=( $(
 		find -name 'Dockerfile' -exec awk '
 				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|.*\/.*)(:|$)/ {
 					print "'"$officialImagesUrl"'" $2


### PR DESCRIPTION
While running the generate-stackbrew-library.sh I was getting the following error:
`./generate-stackbrew-library.sh: line 124: parentRepoToArches[$variantParent]: unbound variable`

I was able to trace it to scope issue with the parentRepoToArches variable and fix by splitting the variable declaration and assignment.