### PR TITLE
Exclude mips64le from 7.2

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -123,6 +123,17 @@ for version in "${versions[@]}"; do
 			variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$dir/Dockerfile")"
 			variantArches="${parentRepoToArches[$variantParent]}"
 
+			if [ "$version" = '7.2' ]; then
+				# PHP 7.2 doesn't compile on MIPS:
+				#   /usr/src/php/ext/pcre/pcrelib/sljit/sljitNativeMIPS_common.c:506:3: error: a label can only be part of a statement and a declaration is not a statement
+				#      sljit_sw fir;
+				#      ^~~~~~~~
+				# According to https://github.com/openwrt/packages/issues/5333 + https://github.com/openwrt/packages/pull/5335,
+				# https://github.com/svn2github/pcre/commit/e5045fd31a2e171dff305665e2b921d7c93427b8#diff-291428aa92cf90de0f2486f9c2829158
+				# *might* fix it, but it's likely not worth it just for PHP 7.2 on MIPS (since 7.3 and 7.4 work fine).
+				variantArches="$(echo " $variantArches " | sed -e 's/ mips64le / /g')"
+			fi
+
 			echo
 			cat <<-EOE
 				Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
Just to have it also written down somewhere, here's the full error:

```console
In file included from /usr/src/php/ext/pcre/pcrelib/sljit/sljitLir.c:1747,
                 from /usr/src/php/ext/pcre/pcrelib/pcre_jit_compile.c:62:
/usr/src/php/ext/pcre/pcrelib/sljit/sljitNativeMIPS_common.c: In function 'sljit_has_cpu_feature':
/usr/src/php/ext/pcre/pcrelib/sljit/sljitNativeMIPS_common.c:506:3: error: a label can only be part of a statement and a declaration is not a statement
   sljit_sw fir;
   ^~~~~~~~
make: *** [Makefile:670: ext/pcre/pcrelib/pcre_jit_compile.lo] Error 1
make: *** Waiting for unfinished jobs....
```

See the comments in the code for more details.