### PR TITLE
Update upstream download URLs

### DIFF
--- a/7.2/alpine3.10/cli/Dockerfile
+++ b/7.2/alpine3.10/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/alpine3.10/fpm/Dockerfile
+++ b/7.2/alpine3.10/fpm/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/alpine3.10/zts/Dockerfile
+++ b/7.2/alpine3.10/zts/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/alpine3.11/cli/Dockerfile
+++ b/7.2/alpine3.11/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/alpine3.11/fpm/Dockerfile
+++ b/7.2/alpine3.11/fpm/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/alpine3.11/zts/Dockerfile
+++ b/7.2/alpine3.11/zts/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/buster/apache/Dockerfile
+++ b/7.2/buster/apache/Dockerfile
@@ -124,7 +124,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/buster/cli/Dockerfile
+++ b/7.2/buster/cli/Dockerfile
@@ -64,7 +64,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/buster/fpm/Dockerfile
+++ b/7.2/buster/fpm/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/buster/zts/Dockerfile
+++ b/7.2/buster/zts/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -124,7 +124,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -64,7 +64,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F
 
 ENV PHP_VERSION 7.2.30
-ENV PHP_URL="https://www.php.net/get/php-7.2.30.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.2.30.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.2.30.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.30.tar.xz.asc"
 ENV PHP_SHA256="aa93df27b58a45d6c9800ac813245dfdca03490a918ebe515b3a70189b1bf8c3" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/alpine3.10/cli/Dockerfile
+++ b/7.3/alpine3.10/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/alpine3.10/fpm/Dockerfile
+++ b/7.3/alpine3.10/fpm/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/alpine3.10/zts/Dockerfile
+++ b/7.3/alpine3.10/zts/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/alpine3.11/cli/Dockerfile
+++ b/7.3/alpine3.11/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/alpine3.11/fpm/Dockerfile
+++ b/7.3/alpine3.11/fpm/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/alpine3.11/zts/Dockerfile
+++ b/7.3/alpine3.11/zts/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/buster/apache/Dockerfile
+++ b/7.3/buster/apache/Dockerfile
@@ -124,7 +124,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/buster/cli/Dockerfile
+++ b/7.3/buster/cli/Dockerfile
@@ -64,7 +64,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/buster/fpm/Dockerfile
+++ b/7.3/buster/fpm/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/buster/zts/Dockerfile
+++ b/7.3/buster/zts/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/stretch/apache/Dockerfile
+++ b/7.3/stretch/apache/Dockerfile
@@ -124,7 +124,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/stretch/cli/Dockerfile
+++ b/7.3/stretch/cli/Dockerfile
@@ -64,7 +64,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/stretch/fpm/Dockerfile
+++ b/7.3/stretch/fpm/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.3/stretch/zts/Dockerfile
+++ b/7.3/stretch/zts/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D
 
 ENV PHP_VERSION 7.3.17
-ENV PHP_URL="https://www.php.net/get/php-7.3.17.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.3.17.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.3.17.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.17.tar.xz.asc"
 ENV PHP_SHA256="6a30304c27f7e7a94538f5ffec599f600ee93aedbbecad8aa4f8bec539b10ad8" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/alpine3.10/cli/Dockerfile
+++ b/7.4/alpine3.10/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/alpine3.10/fpm/Dockerfile
+++ b/7.4/alpine3.10/fpm/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/alpine3.10/zts/Dockerfile
+++ b/7.4/alpine3.10/zts/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/alpine3.11/cli/Dockerfile
+++ b/7.4/alpine3.11/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/alpine3.11/fpm/Dockerfile
+++ b/7.4/alpine3.11/fpm/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/alpine3.11/zts/Dockerfile
+++ b/7.4/alpine3.11/zts/Dockerfile
@@ -63,7 +63,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -124,7 +124,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -64,7 +64,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -65,7 +65,7 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312
 
 ENV PHP_VERSION 7.4.5
-ENV PHP_URL="https://www.php.net/get/php-7.4.5.tar.xz/from/this/mirror" PHP_ASC_URL="https://www.php.net/get/php-7.4.5.tar.xz.asc/from/this/mirror"
+ENV PHP_URL="https://www.php.net/distributions/php-7.4.5.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.5.tar.xz.asc"
 ENV PHP_SHA256="d059fd7f55bdc4d2eada15a00a2976697010d3631ef6f83149cc5289e1f23c2c" PHP_MD5=""
 
 RUN set -eux; \

--- a/update.sh
+++ b/update.sh
@@ -58,8 +58,8 @@ for version in "${versions[@]}"; do
 			.[$version].source[]
 			| select(.filename | endswith(".xz"))
 			|
-				"https://www.php.net/get/" + .filename + "/from/this/mirror",
-				"https://www.php.net/get/" + .filename + ".asc/from/this/mirror",
+				"https://www.php.net/distributions/" + .filename,
+				"https://www.php.net/distributions/" + .filename + ".asc",
 				.sha256 // "",
 				.md5 // ""
 		) ]


### PR DESCRIPTION
These are the URLs listed on https://www.php.net/downloads (and the URLs Homebrew is using), so they seem more appropriate/correct than these older URLs we've been using.

This is pulled out from https://github.com/docker-library/php/pull/1011 (as discussed in https://github.com/docker-library/php/pull/1011#discussion_r417040680).