### PR TITLE
Update to PHP 8.0.0alpha2

### DIFF
--- a/8.0-rc/alpine3.12/cli/Dockerfile
+++ b/8.0-rc/alpine3.12/cli/Dockerfile
@@ -61,9 +61,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha1
-ENV PHP_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="2ab527b3b96908b123271ee390ea01169effeb5027a7f85dbe4d0d37d7da1628" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha2
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/alpine3.12/fpm/Dockerfile
+++ b/8.0-rc/alpine3.12/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha1
-ENV PHP_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="2ab527b3b96908b123271ee390ea01169effeb5027a7f85dbe4d0d37d7da1628" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha2
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/apache/Dockerfile
+++ b/8.0-rc/buster/apache/Dockerfile
@@ -123,9 +123,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha1
-ENV PHP_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="2ab527b3b96908b123271ee390ea01169effeb5027a7f85dbe4d0d37d7da1628" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha2
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/cli/Dockerfile
+++ b/8.0-rc/buster/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha1
-ENV PHP_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="2ab527b3b96908b123271ee390ea01169effeb5027a7f85dbe4d0d37d7da1628" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha2
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha1
-ENV PHP_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="2ab527b3b96908b123271ee390ea01169effeb5027a7f85dbe4d0d37d7da1628" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha2
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/zts/Dockerfile
+++ b/8.0-rc/buster/zts/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha1
-ENV PHP_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~pollita/php-8.0.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="2ab527b3b96908b123271ee390ea01169effeb5027a7f85dbe4d0d37d7da1628" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha2
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
 
 RUN set -eux; \
 	\


### PR DESCRIPTION
Release notes: https://www.php.net/archive/2020.php#2020-07-09-1
Manifest: https://gist.github.com/carusogabriel/0ae8a6238ab9336be7d8e1eb6873888f

Question: where is the documentation on how to run `./update.sh`?