### PR TITLE
Updating php from alpha2 to alpha3

### DIFF
--- a/8.0-rc/alpine3.12/cli/Dockerfile
+++ b/8.0-rc/alpine3.12/cli/Dockerfile
@@ -61,9 +61,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha2
-ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
-ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha3
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz.asc"
+ENV PHP_SHA256="83dac88c90bf47fad89bb2425d76243fa0356e462954d652893d05b9593ac6d0" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/alpine3.12/fpm/Dockerfile
+++ b/8.0-rc/alpine3.12/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha2
-ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
-ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha3
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz.asc"
+ENV PHP_SHA256="83dac88c90bf47fad89bb2425d76243fa0356e462954d652893d05b9593ac6d0" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/apache/Dockerfile
+++ b/8.0-rc/buster/apache/Dockerfile
@@ -123,9 +123,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha2
-ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
-ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha3
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz.asc"
+ENV PHP_SHA256="83dac88c90bf47fad89bb2425d76243fa0356e462954d652893d05b9593ac6d0" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/cli/Dockerfile
+++ b/8.0-rc/buster/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha2
-ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
-ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha3
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz.asc"
+ENV PHP_SHA256="83dac88c90bf47fad89bb2425d76243fa0356e462954d652893d05b9593ac6d0" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha2
-ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
-ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha3
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz.asc"
+ENV PHP_SHA256="83dac88c90bf47fad89bb2425d76243fa0356e462954d652893d05b9593ac6d0" PHP_MD5=""
 
 RUN set -eux; \
 	\

--- a/8.0-rc/buster/zts/Dockerfile
+++ b/8.0-rc/buster/zts/Dockerfile
@@ -64,9 +64,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F
 
-ENV PHP_VERSION 8.0.0alpha2
-ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha2.tar.xz.asc"
-ENV PHP_SHA256="9071e16db76a91df4b8d485eff0d7a40f57053c97709ceb59912c99ac4b95d89" PHP_MD5=""
+ENV PHP_VERSION 8.0.0alpha3
+ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0alpha3.tar.xz.asc"
+ENV PHP_SHA256="83dac88c90bf47fad89bb2425d76243fa0356e462954d652893d05b9593ac6d0" PHP_MD5=""
 
 RUN set -eux; \
 	\


### PR DESCRIPTION
Release Notes:
https://www.php.net/archive/2020.php#2020-07-23-1
Download-Repository:
https://downloads.php.net/~carusogabriel/
Manifest:
https://gist.github.com/carusogabriel/6e0b8b33ee4dd2da23002863af4de965