### PR TITLE
Reduce image size by removing the php source

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -19,6 +19,7 @@ RUN apk add --no-cache \
 		curl \
 		tar \
 		xz \
+		gnupg \
 # https://github.com/docker-library/php/issues/494
 		openssl
 
@@ -59,38 +60,10 @@ ENV PHP_VERSION %%PHP_VERSION%%
 ENV PHP_URL="%%PHP_URL%%" PHP_ASC_URL="%%PHP_ASC_URL%%"
 ENV PHP_SHA256="%%PHP_SHA256%%" PHP_MD5="%%PHP_MD5%%"
 
-RUN set -eux; \
-	\
-	apk add --no-cache --virtual .fetch-deps gnupg; \
-	\
-	mkdir -p /usr/src; \
-	cd /usr/src; \
-	\
-	curl -fsSL -o php.tar.xz "$PHP_URL"; \
-	\
-	if [ -n "$PHP_SHA256" ]; then \
-		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
-	fi; \
-	\
-	if [ -n "$PHP_ASC_URL" ]; then \
-		curl -fsSL -o php.tar.xz.asc "$PHP_ASC_URL"; \
-		export GNUPGHOME="$(mktemp -d)"; \
-		for key in $GPG_KEYS; do \
-			gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-		done; \
-		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
-		gpgconf --kill all; \
-		rm -rf "$GNUPGHOME"; \
-	fi; \
-	\
-	apk del --no-network .fetch-deps
-
 COPY docker-php-source /usr/local/bin/
 
 RUN set -eux; \
+    docker-php-source download; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
 		argon2-dev \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -30,6 +30,7 @@ RUN set -eux; \
 		ca-certificates \
 		curl \
 		xz-utils \
+		gnupg \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -61,44 +62,12 @@ ENV PHP_VERSION %%PHP_VERSION%%
 ENV PHP_URL="%%PHP_URL%%" PHP_ASC_URL="%%PHP_ASC_URL%%"
 ENV PHP_SHA256="%%PHP_SHA256%%" PHP_MD5="%%PHP_MD5%%"
 
-RUN set -eux; \
-	\
-	savedAptMark="$(apt-mark showmanual)"; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends gnupg dirmngr; \
-	rm -rf /var/lib/apt/lists/*; \
-	\
-	mkdir -p /usr/src; \
-	cd /usr/src; \
-	\
-	curl -fsSL -o php.tar.xz "$PHP_URL"; \
-	\
-	if [ -n "$PHP_SHA256" ]; then \
-		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
-	fi; \
-	\
-	if [ -n "$PHP_ASC_URL" ]; then \
-		curl -fsSL -o php.tar.xz.asc "$PHP_ASC_URL"; \
-		export GNUPGHOME="$(mktemp -d)"; \
-		for key in $GPG_KEYS; do \
-			gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-		done; \
-		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
-		gpgconf --kill all; \
-		rm -rf "$GNUPGHOME"; \
-	fi; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	apt-mark manual $savedAptMark > /dev/null; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
-
 COPY docker-php-source /usr/local/bin/
 
 RUN set -eux; \
 	\
+	docker-php-source download; \
+    \
 	savedAptMark="$(apt-mark showmanual)"; \
 ##<argon2-stretch>##
 	sed -e 's/stretch/buster/g' /etc/apt/sources.list > /etc/apt/sources.list.d/buster.list; \

--- a/docker-php-source
+++ b/docker-php-source
@@ -9,13 +9,66 @@ usage() {
 	echo "Manage php source tarball lifecycle."
 	echo
 	echo "Commands:"
-	echo "   extract  extract php source tarball into directory $dir if not already done."
-	echo "   delete   delete extracted php source located into $dir if not already done."
+	echo "   extract         extract php source tarball into directory $dir if not already done."
+	echo "   delete          delete extracted php source located into $dir if not already done."
+	echo "   download        download PHP source code."
+	echo "   delete-download delete the downloaded PHP source code"
 	echo
+}
+
+download() {
+    local url="$1"
+    local url_asc="$2"
+    local sha265="$3"
+    local md5="$4"
+    local gpg_keys="$5"
+
+    if [ -z "$url" ]; then
+        echo "You need to set the PHP source download url with \$PHP_URL"
+        exit 1
+    fi
+
+    if [ -z "$url_asc" ] && [ -z "$sha265" ] && [ -z "$md5" ] && [ -z "$gpg_keys" ]; then
+        echo -n "WARNING: Neither of \$PHP_ASC_URL, \$PHP_SHA256, \$PHP_MD5 nor \$GPG_KEYS specified."
+        echo " Will not verify download."
+    fi
+
+    if [ ! -f /usr/src/php.tar.xz ]; then
+        mkdir -p /usr/src
+
+        curl -fsSL -o /usr/src/php.tar.xz "$url"
+
+        if [ -n "$sha256" ]; then
+            echo "$sha256 *php.tar.xz" | sha256sum -c -
+        fi
+
+        if [ -n "$md5" ]; then
+            echo "$md5 *php.tar.xz" | md5sum -c -
+        fi
+
+        if [ -n "$url_asc" ]; then
+            curl -fsSL -o /usr/src/php.tar.xz.asc "$url_asc"
+            export GNUPGHOME="$(mktemp -d)"
+            for key in $gpg_keys; do
+                gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"
+            done
+            gpg --batch --verify /usr/src/php.tar.xz.asc /usr/src/php.tar.xz
+            gpgconf --kill all
+            rm -rf "$GNUPGHOME"
+        fi
+    fi
+}
+
+deleteSource() {
+    rm -f /usr/src/php.tar.xz /usr/src/php.tar.xz.asc
 }
 
 case "$1" in
 	extract)
+        if [ -n "$PHP_URL" ]; then
+            download "$PHP_URL" "$PHP_ASC_URL" "$PHP_SHA256" "$PHP_MD5" "$GPG_KEYS"
+        fi
+
 		mkdir -p "$dir"
 		if [ ! -f "$dir/.docker-extracted" ]; then
 			tar -Jxf /usr/src/php.tar.xz -C "$dir" --strip-components=1
@@ -25,7 +78,19 @@ case "$1" in
 
 	delete)
 		rm -rf "$dir"
+
+        if [ -n "$PHP_URL" ]; then
+            deleteSource
+        fi
 		;;
+
+    download)
+        download "$PHP_URL" "$PHP_ASC_URL" "$PHP_SHA256" "$PHP_MD5" "$GPG_KEYS"
+        ;;
+
+    delete-download)
+        deleteSource
+        ;;
 
 	*)
 		usage


### PR DESCRIPTION
Hello,

I've reduced the size of all images by around 10 MB by removing the source code of PHP after compiling it.

To download and delete and the source code again I've added the sub-commands `download` and `delete-download` to `docker-php-source` script, which are called when `docker-php-source extract` and `docker-php-source delete` are executed. This allows `docker-php-ext-install` to work as before.

Possible BC breaks:
1. Installs through pecl
2. Compiling extension directly
3. environment variable `PHP_URL` was removed

For 1. and 2. `docker-php-source download` must called before and `docker-php-source delete-download` for cleanup must be called after.

Of cause the overall build time of the php images increased for most people, but should be acceptable.

I've a quite complex image based on this PHP images and it could be build without problems, so I guess most people won't even notice.