### PR TITLE
Drop `.so` from "extension=" in docker-php-ext-enable generated ini files

### DIFF
--- a/7.2/alpine3.11/cli/docker-php-ext-enable
+++ b/7.2/alpine3.11/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/alpine3.11/fpm/docker-php-ext-enable
+++ b/7.2/alpine3.11/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/alpine3.11/zts/docker-php-ext-enable
+++ b/7.2/alpine3.11/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/alpine3.12/cli/docker-php-ext-enable
+++ b/7.2/alpine3.12/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/alpine3.12/fpm/docker-php-ext-enable
+++ b/7.2/alpine3.12/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/alpine3.12/zts/docker-php-ext-enable
+++ b/7.2/alpine3.12/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/buster/apache/docker-php-ext-enable
+++ b/7.2/buster/apache/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/buster/cli/docker-php-ext-enable
+++ b/7.2/buster/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/buster/fpm/docker-php-ext-enable
+++ b/7.2/buster/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/buster/zts/docker-php-ext-enable
+++ b/7.2/buster/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/stretch/apache/docker-php-ext-enable
+++ b/7.2/stretch/apache/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/stretch/cli/docker-php-ext-enable
+++ b/7.2/stretch/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/stretch/fpm/docker-php-ext-enable
+++ b/7.2/stretch/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.2/stretch/zts/docker-php-ext-enable
+++ b/7.2/stretch/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/alpine3.11/cli/docker-php-ext-enable
+++ b/7.3/alpine3.11/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/alpine3.11/fpm/docker-php-ext-enable
+++ b/7.3/alpine3.11/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/alpine3.11/zts/docker-php-ext-enable
+++ b/7.3/alpine3.11/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/alpine3.12/cli/docker-php-ext-enable
+++ b/7.3/alpine3.12/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/alpine3.12/fpm/docker-php-ext-enable
+++ b/7.3/alpine3.12/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/alpine3.12/zts/docker-php-ext-enable
+++ b/7.3/alpine3.12/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/buster/apache/docker-php-ext-enable
+++ b/7.3/buster/apache/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/buster/cli/docker-php-ext-enable
+++ b/7.3/buster/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/buster/fpm/docker-php-ext-enable
+++ b/7.3/buster/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/buster/zts/docker-php-ext-enable
+++ b/7.3/buster/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/stretch/apache/docker-php-ext-enable
+++ b/7.3/stretch/apache/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/stretch/cli/docker-php-ext-enable
+++ b/7.3/stretch/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/stretch/fpm/docker-php-ext-enable
+++ b/7.3/stretch/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.3/stretch/zts/docker-php-ext-enable
+++ b/7.3/stretch/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/alpine3.11/cli/docker-php-ext-enable
+++ b/7.4/alpine3.11/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/alpine3.11/fpm/docker-php-ext-enable
+++ b/7.4/alpine3.11/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/alpine3.11/zts/docker-php-ext-enable
+++ b/7.4/alpine3.11/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/alpine3.12/cli/docker-php-ext-enable
+++ b/7.4/alpine3.12/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/alpine3.12/fpm/docker-php-ext-enable
+++ b/7.4/alpine3.12/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/alpine3.12/zts/docker-php-ext-enable
+++ b/7.4/alpine3.12/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/buster/apache/docker-php-ext-enable
+++ b/7.4/buster/apache/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/buster/cli/docker-php-ext-enable
+++ b/7.4/buster/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/buster/fpm/docker-php-ext-enable
+++ b/7.4/buster/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/7.4/buster/zts/docker-php-ext-enable
+++ b/7.4/buster/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/8.0-rc/alpine3.12/cli/docker-php-ext-enable
+++ b/8.0-rc/alpine3.12/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/8.0-rc/alpine3.12/fpm/docker-php-ext-enable
+++ b/8.0-rc/alpine3.12/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/8.0-rc/buster/apache/docker-php-ext-enable
+++ b/8.0-rc/buster/apache/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/8.0-rc/buster/cli/docker-php-ext-enable
+++ b/8.0-rc/buster/cli/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/8.0-rc/buster/fpm/docker-php-ext-enable
+++ b/8.0-rc/buster/fpm/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/8.0-rc/buster/zts/docker-php-ext-enable
+++ b/8.0-rc/buster/zts/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -48,11 +48,7 @@ for module; do
 	if [ -z "$module" ]; then
 		continue
 	fi
-	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
-		# allow ".so" to be optional
-		module="$module.so"
-	fi
-	if ! [ -f "$module" ]; then
+	if ! [ -f "$module" ] && ! [ -f "$module.so" ]; then
 		echo >&2 "error: '$module' does not exist"
 		echo >&2
 		usage >&2
@@ -84,10 +80,13 @@ if [ "$pm" = 'apk' ]; then
 fi
 
 for module in $modules; do
-	if readelf --wide --syms "$module" | grep -q ' zend_extension_entry$'; then
+	moduleFile="$module"
+	if [ -f "$module.so" ] && ! [ -f "$module" ]; then
+		moduleFile="$module.so"
+	fi
+	if readelf --wide --syms "$moduleFile" | grep -q ' zend_extension_entry$'; then
 		# https://wiki.php.net/internals/extensions#loading_zend_extensions
-		absModule="$(readlink -f "$module")"
-		line="zend_extension=$absModule"
+		line="zend_extension=$module"
 	else
 		line="extension=$module"
 	fi


### PR DESCRIPTION
This unfortunately does not significantly simplify `-ext-enable`, but does make cleaner ini files.

Fixes #1069

Also drop the absolute path for `zend_extension=`, since they work fine without it. :shrug: 