### PR TITLE
Drop md5 checksums

### DIFF
--- a/7.2/alpine3.11/cli/Dockerfile
+++ b/7.2/alpine3.11/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/alpine3.11/fpm/Dockerfile
+++ b/7.2/alpine3.11/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/alpine3.11/zts/Dockerfile
+++ b/7.2/alpine3.11/zts/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/alpine3.12/cli/Dockerfile
+++ b/7.2/alpine3.12/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/alpine3.12/fpm/Dockerfile
+++ b/7.2/alpine3.12/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/alpine3.12/zts/Dockerfile
+++ b/7.2/alpine3.12/zts/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/buster/apache/Dockerfile
+++ b/7.2/buster/apache/Dockerfile
@@ -123,7 +123,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -139,9 +139,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/buster/cli/Dockerfile
+++ b/7.2/buster/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -78,9 +78,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/buster/fpm/Dockerfile
+++ b/7.2/buster/fpm/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/buster/zts/Dockerfile
+++ b/7.2/buster/zts/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/stretch/apache/Dockerfile
+++ b/7.2/stretch/apache/Dockerfile
@@ -123,7 +123,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -139,9 +139,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/stretch/cli/Dockerfile
+++ b/7.2/stretch/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -78,9 +78,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/stretch/fpm/Dockerfile
+++ b/7.2/stretch/fpm/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.2/stretch/zts/Dockerfile
+++ b/7.2/stretch/zts/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC
 
 ENV PHP_VERSION 7.2.34
 ENV PHP_URL="https://www.php.net/distributions/php-7.2.34.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.2.34.tar.xz.asc"
-ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903" PHP_MD5=""
+ENV PHP_SHA256="409e11bc6a2c18707dfc44bc61c820ddfd81e17481470f3405ee7822d8379903"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/alpine3.11/cli/Dockerfile
+++ b/7.3/alpine3.11/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/alpine3.11/fpm/Dockerfile
+++ b/7.3/alpine3.11/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/alpine3.11/zts/Dockerfile
+++ b/7.3/alpine3.11/zts/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/alpine3.12/cli/Dockerfile
+++ b/7.3/alpine3.12/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/alpine3.12/fpm/Dockerfile
+++ b/7.3/alpine3.12/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/alpine3.12/zts/Dockerfile
+++ b/7.3/alpine3.12/zts/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/buster/apache/Dockerfile
+++ b/7.3/buster/apache/Dockerfile
@@ -123,7 +123,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -139,9 +139,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/buster/cli/Dockerfile
+++ b/7.3/buster/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -78,9 +78,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/buster/fpm/Dockerfile
+++ b/7.3/buster/fpm/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/buster/zts/Dockerfile
+++ b/7.3/buster/zts/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/stretch/apache/Dockerfile
+++ b/7.3/stretch/apache/Dockerfile
@@ -123,7 +123,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -139,9 +139,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/stretch/cli/Dockerfile
+++ b/7.3/stretch/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -78,9 +78,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/stretch/fpm/Dockerfile
+++ b/7.3/stretch/fpm/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.3/stretch/zts/Dockerfile
+++ b/7.3/stretch/zts/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F
 
 ENV PHP_VERSION 7.3.24
 ENV PHP_URL="https://www.php.net/distributions/php-7.3.24.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.3.24.tar.xz.asc"
-ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888" PHP_MD5=""
+ENV PHP_SHA256="78b0b417a147ab7572c874334d11654e3c61ec5b3f2170098e5db02fb0c89888"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/alpine3.11/cli/Dockerfile
+++ b/7.4/alpine3.11/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/alpine3.11/fpm/Dockerfile
+++ b/7.4/alpine3.11/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/alpine3.11/zts/Dockerfile
+++ b/7.4/alpine3.11/zts/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/alpine3.12/cli/Dockerfile
+++ b/7.4/alpine3.12/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/alpine3.12/fpm/Dockerfile
+++ b/7.4/alpine3.12/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/alpine3.12/zts/Dockerfile
+++ b/7.4/alpine3.12/zts/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -123,7 +123,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -139,9 +139,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -78,9 +78,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC91
 
 ENV PHP_VERSION 7.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-7.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-7.4.12.tar.xz.asc"
-ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76" PHP_MD5=""
+ENV PHP_SHA256="e82d2bcead05255f6b7d2ff4e2561bc334204955820cabc2457b5239fde96b76"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/8.0-rc/alpine3.12/cli/Dockerfile
+++ b/8.0-rc/alpine3.12/cli/Dockerfile
@@ -60,7 +60,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B
 
 ENV PHP_VERSION 8.0.0RC3
 ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz.asc"
-ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa" PHP_MD5=""
+ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa"
 
 RUN set -eux; \
 	\
@@ -73,9 +73,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/8.0-rc/alpine3.12/fpm/Dockerfile
+++ b/8.0-rc/alpine3.12/fpm/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B
 
 ENV PHP_VERSION 8.0.0RC3
 ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz.asc"
-ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa" PHP_MD5=""
+ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa"
 
 RUN set -eux; \
 	\
@@ -75,9 +75,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/8.0-rc/buster/apache/Dockerfile
+++ b/8.0-rc/buster/apache/Dockerfile
@@ -123,7 +123,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B
 
 ENV PHP_VERSION 8.0.0RC3
 ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz.asc"
-ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa" PHP_MD5=""
+ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa"
 
 RUN set -eux; \
 	\
@@ -139,9 +139,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/8.0-rc/buster/cli/Dockerfile
+++ b/8.0-rc/buster/cli/Dockerfile
@@ -62,7 +62,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B
 
 ENV PHP_VERSION 8.0.0RC3
 ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz.asc"
-ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa" PHP_MD5=""
+ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa"
 
 RUN set -eux; \
 	\
@@ -78,9 +78,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B
 
 ENV PHP_VERSION 8.0.0RC3
 ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz.asc"
-ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa" PHP_MD5=""
+ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/8.0-rc/buster/zts/Dockerfile
+++ b/8.0-rc/buster/zts/Dockerfile
@@ -64,7 +64,7 @@ ENV GPG_KEYS 1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B
 
 ENV PHP_VERSION 8.0.0RC3
 ENV PHP_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz" PHP_ASC_URL="https://downloads.php.net/~carusogabriel/php-8.0.0RC3.tar.xz.asc"
-ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa" PHP_MD5=""
+ENV PHP_SHA256="3438b3adf87ee65ba7d90db189cabc0a0a42ffc39bb7ae93f65cf6080a68ebfa"
 
 RUN set -eux; \
 	\
@@ -80,9 +80,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -59,7 +59,7 @@ ENV GPG_KEYS {{ .gpgKeys }}
 
 ENV PHP_VERSION {{ .version }}
 ENV PHP_URL="{{ .url }}" PHP_ASC_URL="{{ .ascUrl // "" }}"
-ENV PHP_SHA256="{{ .sha256 // "" }}" PHP_MD5="{{ .md5 // "" }}"
+ENV PHP_SHA256="{{ .sha256 // "" }}"
 
 RUN set -eux; \
 	\
@@ -72,9 +72,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -61,7 +61,7 @@ ENV GPG_KEYS {{ .gpgKeys }}
 
 ENV PHP_VERSION {{ .version }}
 ENV PHP_URL="{{ .url }}" PHP_ASC_URL="{{ .ascUrl // "" }}"
-ENV PHP_SHA256="{{ .sha256 // "" }}" PHP_MD5="{{ .md5 // "" }}"
+ENV PHP_SHA256="{{ .sha256 // "" }}"
 
 RUN set -eux; \
 	\
@@ -77,9 +77,6 @@ RUN set -eux; \
 	\
 	if [ -n "$PHP_SHA256" ]; then \
 		echo "$PHP_SHA256 *php.tar.xz" | sha256sum -c -; \
-	fi; \
-	if [ -n "$PHP_MD5" ]; then \
-		echo "$PHP_MD5 *php.tar.xz" | md5sum -c -; \
 	fi; \
 	\
 	if [ -n "$PHP_ASC_URL" ]; then \

--- a/versions.sh
+++ b/versions.sh
@@ -52,8 +52,7 @@ for version in "${versions[@]}"; do
 				|
 					"https://www.php.net/distributions/" + .filename,
 					"https://www.php.net/distributions/" + .filename + ".asc",
-					.sha256 // "",
-					.md5 // ""
+					.sha256 // ""
 			) ]
 		'
 	else
@@ -65,8 +64,7 @@ for version in "${versions[@]}"; do
 				.version,
 				.files.xz.path // "",
 				"",
-				.files.xz.sha256 // "",
-				.files.xz.md5 // ""
+				.files.xz.sha256 // ""
 			]
 		'
 	fi
@@ -85,14 +83,13 @@ for version in "${versions[@]}"; do
 		exit 1
 	fi
 
-	# format of "possibles" array entries is "VERSION URL.TAR.XZ URL.TAR.XZ.ASC SHA256 MD5" (each value shell quoted)
+	# format of "possibles" array entries is "VERSION URL.TAR.XZ URL.TAR.XZ.ASC SHA256" (each value shell quoted)
 	#   see the "apiJqExpr" values above for more details
 	eval "possi=( ${possibles[0]} )"
 	fullVersion="${possi[0]}"
 	url="${possi[1]}"
 	ascUrl="${possi[2]}"
 	sha256="${possi[3]}"
-	md5="${possi[4]}"
 
 	gpgKey="${gpgKeys[$rcVersion]:-}"
 	if [ -z "$gpgKey" ]; then
@@ -129,7 +126,7 @@ for version in "${versions[@]}"; do
 
 	echo "$version: $fullVersion"
 
-	export fullVersion url ascUrl sha256 md5 gpgKey
+	export fullVersion url ascUrl sha256 gpgKey
 	json="$(
 		jq <<<"$json" -c \
 			--argjson variants "$variants" \


### PR DESCRIPTION
There hasn't been a recent releases that even has an md5 (like [7.4](https://www.php.net/releases/index.php?json&max=100&version=7.4)). And `versions.sh` hasn't even put the empty value into `versions.json`(see [lines 132-144](https://github.com/docker-library/php/blob/0f0ddeac8b53fa936d870f56589abcf5646b65a8/versions.sh#L132-L144)) to be used by the Dockerfile templates.

Closes #1077