### PR TITLE
Configure PHP with pear/pecl installers for PHP 8.0

### DIFF
--- a/7.4/alpine3.11/cli/Dockerfile
+++ b/7.4/alpine3.11/cli/Dockerfile
@@ -146,7 +146,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/alpine3.11/fpm/Dockerfile
+++ b/7.4/alpine3.11/fpm/Dockerfile
@@ -148,7 +148,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/alpine3.11/zts/Dockerfile
+++ b/7.4/alpine3.11/zts/Dockerfile
@@ -148,7 +148,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/alpine3.12/cli/Dockerfile
+++ b/7.4/alpine3.12/cli/Dockerfile
@@ -146,7 +146,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/alpine3.12/fpm/Dockerfile
+++ b/7.4/alpine3.12/fpm/Dockerfile
@@ -148,7 +148,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/alpine3.12/zts/Dockerfile
+++ b/7.4/alpine3.12/zts/Dockerfile
@@ -148,7 +148,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -223,7 +223,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -162,7 +162,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -164,7 +164,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -164,7 +164,6 @@ RUN set -eux; \
 		--with-zlib \
 		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 # bundled pcre does not support JIT on s390x

--- a/8.0-rc/alpine3.12/cli/Dockerfile
+++ b/8.0-rc/alpine3.12/cli/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/8.0-rc/alpine3.12/fpm/Dockerfile
+++ b/8.0-rc/alpine3.12/fpm/Dockerfile
@@ -147,6 +147,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/8.0-rc/buster/apache/Dockerfile
+++ b/8.0-rc/buster/apache/Dockerfile
@@ -222,6 +222,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/8.0-rc/buster/cli/Dockerfile
+++ b/8.0-rc/buster/cli/Dockerfile
@@ -161,6 +161,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -163,6 +163,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/8.0-rc/buster/zts/Dockerfile
+++ b/8.0-rc/buster/zts/Dockerfile
@@ -163,6 +163,9 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
+# in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
+		--with-pear \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/stretch/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -155,9 +155,8 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
-{{ if (.version | version_id) | . >= ("7.4" | version_id) and . < ("8" | version_id) then ( -}}
+{{ if (.version | version_id) | . >= ("7.4" | version_id) then ( -}}
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 {{ ) else "" end -}}

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -184,9 +184,8 @@ RUN set -eux; \
 		--with-openssl \
 		--with-zlib \
 		\
-{{ if (.version | version_id) | . >= ("7.4" | version_id) and . < ("8" | version_id) then ( -}}
+{{ if (.version | version_id) | . >= ("7.4" | version_id) then ( -}}
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
-# ... and are removed in PHP 8+; see also https://github.com/docker-library/php/pull/847#issuecomment-505638229
 		--with-pear \
 		\
 {{ ) else "" end -}}


### PR DESCRIPTION
Resolves #1087 

It appears that pear/pecl are not removed in PHP 8.0. Indeed, even the PHP 8.0 changelog mentions needing to install xml-rpc using pecl as of 8.0:

https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.xmlrpc

This means that PHP 7.4 and 8+ can both use the `--with-pear` option.