### PR TITLE
Build cli image with php fpm support

### DIFF
--- a/Dockerfile-cli-block-1.template
+++ b/Dockerfile-cli-block-1.template
@@ -1,4 +1,6 @@
-{{ if env.suite | startswith("alpine") | not then ( -}}
-# https://github.com/docker-library/php/pull/939#issuecomment-730501748
-ENV PHP_EXTRA_CONFIGURE_ARGS --enable-embed
-{{ ) else "" end -}}
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-fpm --with-fpm-user=www-data --with-fpm-group=www-data --disable-cgi {{
+    if env.suite | startswith("alpine") | not then
+        # https://github.com/docker-library/php/pull/939#issuecomment-730501748
+        "--enable-embed"
+    end
+}}


### PR DESCRIPTION
CLI image is often used as a base image with nginx which requires php compiled with fpm support.