### PR TITLE
Adjust "docker-php-ext-enable" to use "grep -Fx"

### DIFF
--- a/7.3/alpine3.12/cli/docker-php-ext-enable
+++ b/7.3/alpine3.12/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/alpine3.12/fpm/docker-php-ext-enable
+++ b/7.3/alpine3.12/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/alpine3.12/zts/docker-php-ext-enable
+++ b/7.3/alpine3.12/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/alpine3.13/cli/docker-php-ext-enable
+++ b/7.3/alpine3.13/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/alpine3.13/fpm/docker-php-ext-enable
+++ b/7.3/alpine3.13/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/alpine3.13/zts/docker-php-ext-enable
+++ b/7.3/alpine3.13/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/buster/apache/docker-php-ext-enable
+++ b/7.3/buster/apache/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/buster/cli/docker-php-ext-enable
+++ b/7.3/buster/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/buster/fpm/docker-php-ext-enable
+++ b/7.3/buster/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/buster/zts/docker-php-ext-enable
+++ b/7.3/buster/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/stretch/apache/docker-php-ext-enable
+++ b/7.3/stretch/apache/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/stretch/cli/docker-php-ext-enable
+++ b/7.3/stretch/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/stretch/fpm/docker-php-ext-enable
+++ b/7.3/stretch/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.3/stretch/zts/docker-php-ext-enable
+++ b/7.3/stretch/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/alpine3.12/cli/docker-php-ext-enable
+++ b/7.4/alpine3.12/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/alpine3.12/fpm/docker-php-ext-enable
+++ b/7.4/alpine3.12/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/alpine3.12/zts/docker-php-ext-enable
+++ b/7.4/alpine3.12/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/alpine3.13/cli/docker-php-ext-enable
+++ b/7.4/alpine3.13/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/alpine3.13/fpm/docker-php-ext-enable
+++ b/7.4/alpine3.13/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/alpine3.13/zts/docker-php-ext-enable
+++ b/7.4/alpine3.13/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/buster/apache/docker-php-ext-enable
+++ b/7.4/buster/apache/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/buster/cli/docker-php-ext-enable
+++ b/7.4/buster/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/buster/fpm/docker-php-ext-enable
+++ b/7.4/buster/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/7.4/buster/zts/docker-php-ext-enable
+++ b/7.4/buster/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/alpine3.12/cli/docker-php-ext-enable
+++ b/8.0/alpine3.12/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/alpine3.12/fpm/docker-php-ext-enable
+++ b/8.0/alpine3.12/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/alpine3.13/cli/docker-php-ext-enable
+++ b/8.0/alpine3.13/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/alpine3.13/fpm/docker-php-ext-enable
+++ b/8.0/alpine3.13/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/buster/apache/docker-php-ext-enable
+++ b/8.0/buster/apache/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/buster/cli/docker-php-ext-enable
+++ b/8.0/buster/cli/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/buster/fpm/docker-php-ext-enable
+++ b/8.0/buster/fpm/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/8.0/buster/zts/docker-php-ext-enable
+++ b/8.0/buster/zts/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -111,7 +111,7 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -q "$line" "$ini" 2>/dev/null; then
+	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
 		echo "$line" >> "$ini"
 	fi
 done


### PR DESCRIPTION
Also, test both versions (with `.so` and without).

This helps avoid false positives due to lines like `extension=apc` matching `extension=apcu`.

Fixes #1122 (good catch, @chadxz!)