### PR TITLE
Fallback to multiple PGP servers

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -80,7 +80,17 @@ RUN set -eux; \
 		curl -fsSL -o php.tar.xz.asc "$PHP_ASC_URL"; \
 		export GNUPGHOME="$(mktemp -d)"; \
 		for key in $GPG_KEYS; do \
-			gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+			found=''; \
+			for server in \
+				ha.pool.sks-keyservers.net \
+				hkp://keyserver.ubuntu.com:80 \
+				hkp://p80.pool.sks-keyservers.net:80 \
+				pgp.mit.edu \
+			; do \
+				echo "Fetching GPG key $key from $server"; \
+				gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+			done; \
+			test -z "$found" && echo >&2 "error: failed to fetch GPG key $key" && exit 1; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
 		gpgconf --kill all; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -83,7 +83,17 @@ RUN set -eux; \
 		curl -fsSL -o php.tar.xz.asc "$PHP_ASC_URL"; \
 		export GNUPGHOME="$(mktemp -d)"; \
 		for key in $GPG_KEYS; do \
-			gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+			found=''; \
+			for server in \
+				ha.pool.sks-keyservers.net \
+				hkp://keyserver.ubuntu.com:80 \
+				hkp://p80.pool.sks-keyservers.net:80 \
+				pgp.mit.edu \
+			; do \
+				echo "Fetching GPG key $key from $server"; \
+				gpg --batch --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$key" && found=yes && break; \
+			done; \
+			test -z "$found" && echo >&2 "error: failed to fetch GPG key $key" && exit 1; \
 		done; \
 		gpg --batch --verify php.tar.xz.asc php.tar.xz; \
 		gpgconf --kill all; \


### PR DESCRIPTION
This fallback is based on a similar setup for Nginx (https://github.com/nginxinc/docker-nginx/blob/f3fe494531f9b157d9c09ba509e412dace54cd4f/stable/debian/Dockerfile#L23)

SKS seems to be deprecated: https://sks-keyservers.net/status/