### PR TITLE
Upgrade to PHP 8.1.0 alpha2 release

### DIFF
--- a/8.1-rc/alpine3.13/cli/Dockerfile
+++ b/8.1-rc/alpine3.13/cli/Dockerfile
@@ -58,9 +58,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/alpine3.13/fpm/Dockerfile
+++ b/8.1-rc/alpine3.13/fpm/Dockerfile
@@ -60,9 +60,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/alpine3.14/cli/Dockerfile
+++ b/8.1-rc/alpine3.14/cli/Dockerfile
@@ -57,9 +57,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/alpine3.14/fpm/Dockerfile
+++ b/8.1-rc/alpine3.14/fpm/Dockerfile
@@ -59,9 +59,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/buster/apache/Dockerfile
+++ b/8.1-rc/buster/apache/Dockerfile
@@ -121,9 +121,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/buster/cli/Dockerfile
+++ b/8.1-rc/buster/cli/Dockerfile
@@ -63,9 +63,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/buster/fpm/Dockerfile
+++ b/8.1-rc/buster/fpm/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/8.1-rc/buster/zts/Dockerfile
+++ b/8.1-rc/buster/zts/Dockerfile
@@ -62,9 +62,9 @@ ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
 ENV GPG_KEYS 528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD
 
-ENV PHP_VERSION 8.1.0alpha1
-ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc"
-ENV PHP_SHA256="131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79"
+ENV PHP_VERSION 8.1.0alpha2
+ENV PHP_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz" PHP_ASC_URL="https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc"
+ENV PHP_SHA256="916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6"
 
 RUN set -eux; \
 	\

--- a/versions.json
+++ b/versions.json
@@ -59,10 +59,10 @@
     "version": "8.0.7"
   },
   "8.1-rc": {
-    "ascUrl": "https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz.asc",
+    "ascUrl": "https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz.asc",
     "gpgKeys": "528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD",
-    "sha256": "131a81ef9e0d62ba3b5ed81d530a4ff38d256ff12acec243d6afb5b39a85cb79",
-    "url": "https://downloads.php.net/~patrickallaert/php-8.1.0alpha1.tar.xz",
+    "sha256": "916e96eda029198134dd20e50a98b539d70ef204aa241e017c8b2c736222e4c6",
+    "url": "https://downloads.php.net/~patrickallaert/php-8.1.0alpha2.tar.xz",
     "variants": [
       "buster/cli",
       "buster/apache",
@@ -73,6 +73,6 @@
       "alpine3.13/cli",
       "alpine3.13/fpm"
     ],
-    "version": "8.1.0alpha1"
+    "version": "8.1.0alpha2"
   }
 }


### PR DESCRIPTION
This release fixes an issue when compiling the opcache extension reported [here](https://github.com/docker-library/php/issues/1165)