### PR TITLE
Add "--enable-embed" to Debian-based ZTS variants

### DIFF
--- a/7.3/buster/zts/Dockerfile
+++ b/7.3/buster/zts/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
 	chown www-data:www-data /var/www/html; \
 	chmod 777 /var/www/html
 
-ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts --enable-embed --disable-cgi
 
 # Apply stack smash protection to functions using local buffers and alloca()
 # Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)

--- a/7.3/stretch/zts/Dockerfile
+++ b/7.3/stretch/zts/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
 	chown www-data:www-data /var/www/html; \
 	chmod 777 /var/www/html
 
-ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts --enable-embed --disable-cgi
 
 # Apply stack smash protection to functions using local buffers and alloca()
 # Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
 	chown www-data:www-data /var/www/html; \
 	chmod 777 /var/www/html
 
-ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-maintainer-zts --enable-embed --disable-cgi
 
 # Apply stack smash protection to functions using local buffers and alloca()
 # Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)

--- a/8.0/buster/zts/Dockerfile
+++ b/8.0/buster/zts/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
 	chown www-data:www-data /var/www/html; \
 	chmod 777 /var/www/html
 
-ENV PHP_EXTRA_CONFIGURE_ARGS --enable-zts --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-zts --enable-embed --disable-cgi
 
 # Apply stack smash protection to functions using local buffers and alloca()
 # Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)

--- a/8.1-rc/buster/zts/Dockerfile
+++ b/8.1-rc/buster/zts/Dockerfile
@@ -48,7 +48,7 @@ RUN set -eux; \
 	chown www-data:www-data /var/www/html; \
 	chmod 777 /var/www/html
 
-ENV PHP_EXTRA_CONFIGURE_ARGS --enable-zts --disable-cgi
+ENV PHP_EXTRA_CONFIGURE_ARGS --enable-zts --enable-embed --disable-cgi
 
 # Apply stack smash protection to functions using local buffers and alloca()
 # Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)

--- a/Dockerfile-zts-block-1.template
+++ b/Dockerfile-zts-block-1.template
@@ -5,4 +5,9 @@ ENV PHP_EXTRA_CONFIGURE_ARGS {{
 	else
 		"--enable-maintainer-zts"
 	end
+-}}
+{{
+	if env.suite | startswith("alpine") | not then
+		" --enable-embed"
+	else "" end
 }} --disable-cgi


### PR DESCRIPTION
#1104 added the flag to Debian-based CLI variants; we use a Debian-based ZTS variant, and would benefit from this flag as well. 

Also, NGiNX Unit, the use case scenario mentioned in #1104 [seems to be compatible with ZTS](https://github.com/nginx/unit/commit/adf22b6a0d3481f7fc4d38ade08a2a0dd4ea6f19).

Refs #510 #939