### PR TITLE
Allow changing the config file scan dir

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -76,6 +76,8 @@ RUN set -eux; \
 {{ ) end -}}
 
 ENV PHP_INI_DIR /usr/local/etc/php
+# https://www.php.net/manual/en/configuration.file.php#configuration.file.scan
+ENV CONFIG_SCAN_DIRS $PHP_INI_DIR/conf.d
 RUN set -eux; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 # allow running as an arbitrary user (https://github.com/docker-library/php/issues/743)
@@ -267,7 +269,7 @@ RUN set -eux; \
 	./configure \
 		--build="$gnuArch" \
 		--with-config-file-path="$PHP_INI_DIR" \
-		--with-config-file-scan-dir="$PHP_INI_DIR/conf.d" \
+		--with-config-file-scan-dir="$CONFIG_SCAN_DIRS" \
 		\
 # make sure invalid --configure-flags are fatal errors instead of just warnings
 		--enable-option-checking=fatal \


### PR DESCRIPTION
Allow setting --with-config-file-scan-dir's value by introducing
ENV CONFIG_SCAN_DIRS /usr/local/etc/php/conf.d
https://www.php.net/manual/en/configuration.file.php#configuration.file.scan

This would allow for mounting an additional volume with config files from a docker-compose.