### PR TITLE
Add RCs opportunistically

### DIFF
--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -30,6 +30,13 @@ generated_warning() {
 for version; do
 	export version
 
+	rm -rf "$version"
+
+	if jq -e '.[env.version] | not' versions.json > /dev/null; then
+		echo "deleting $version ..."
+		continue
+	fi
+
 	variants="$(jq -r '.[env.version].variants | map(@sh) | join(" ")' versions.json)"
 	eval "variants=( $variants )"
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -21,7 +21,7 @@ self="$(basename "$BASH_SOURCE")"
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 if [ "$#" -eq 0 ]; then
-	versions="$(jq -r 'keys | map(@sh) | join(" ")' versions.json)"
+	versions="$(jq -r 'to_entries | map(if .value then .key | @sh else empty end) | join(" ")' versions.json)"
 	eval "set -- $versions"
 fi
 

--- a/versions.json
+++ b/versions.json
@@ -22,6 +22,7 @@
     ],
     "version": "7.3.33"
   },
+  "7.3-rc": null,
   "7.4": {
     "ascUrl": "https://www.php.net/distributions/php-7.4.27.tar.xz.asc",
     "gpgKeys": "42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312",
@@ -45,6 +46,7 @@
     ],
     "version": "7.4.27"
   },
+  "7.4-rc": null,
   "8.0": {
     "ascUrl": "https://www.php.net/distributions/php-8.0.15.tar.xz.asc",
     "gpgKeys": "1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F",
@@ -66,6 +68,7 @@
     ],
     "version": "8.0.15"
   },
+  "8.0-rc": null,
   "8.1": {
     "ascUrl": "https://www.php.net/distributions/php-8.1.2.tar.xz.asc",
     "gpgKeys": "528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD",
@@ -86,5 +89,6 @@
       "alpine3.14/fpm"
     ],
     "version": "8.1.2"
-  }
+  },
+  "8.1-rc": null
 }


### PR DESCRIPTION
Allow RC builds to come and go automatically as they become available (and disappear).

See also https://github.com/docker-library/docker/pull/332, https://github.com/docker-library/rabbitmq/pull/522, https://github.com/docker-library/mongo/pull/476, and https://github.com/docker-library/oi-janky-groovy/commit/3583ca5.

Closes #1248