### PR TITLE
Move GPG keys into the template

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -154,7 +154,43 @@ ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_
 ENV PHP_CPPFLAGS="$PHP_CFLAGS"
 ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
-ENV GPG_KEYS {{ .gpgKeys }}
+ENV GPG_KEYS {{
+	{
+		# https://www.php.net/gpg-keys.php
+		# https://www.php.net/downloads.php
+
+		"8.1": [
+			# https://wiki.php.net/todo/php81#release_managers
+			# https://www.php.net/gpg-keys.php#gpg-8.1
+			"5289 95BF EDFB A719 1D46  839E F9BA 0ADA 31CB D89E", # krakjoe
+			"39B6 4134 3D8C 104B 2B14  6DC3 F9C3 9DC0 B969 8544", # ramsey
+			"F1F6 9223 8FBC 1666 E5A5  CCD4 199F 9DFE F6FF BAFD"  # patrickallaert
+		],
+
+		"8.0": [
+			# https://wiki.php.net/todo/php80#release_managers
+			# https://www.php.net/gpg-keys.php#gpg-8.0
+			"1729 F839 38DA 44E2 7BA0  F4D3 DBDB 3974 70D1 2172", # pollita
+			"BFDD D286 4282 4F81 18EF  7790 9B67 A5C1 2229 118F"  # carusogabriel
+		],
+
+		"7.4": [
+			# https://wiki.php.net/todo/php74#release_managers
+			# https://www.php.net/gpg-keys.php#gpg-7.4
+			"4267 0A7F E4D0 441C 8E46  3234 9E4F DC07 4A4E F02D", # petk
+			"5A52 8807 81F7 5560 8BF8  15FC 910D EB46 F53E A312"  # derick
+		],
+
+		"7.3": [
+			# https://wiki.php.net/todo/php73#release_managers
+			# https://www.php.net/gpg-keys.php#gpg-7.3
+			"CBAF 69F1 73A0 FEA4 B537  F470 D66C 9593 118B CCB6", # cmb
+			"F382 5282 6ACD 957E F380  D39F 2F79 56BC 5DA0 4B5D"  # stas
+		],
+	}[env.version | rtrimstr("-rc")] // error("missing GPG keys for " + env.version)
+	| map(gsub(" "; ""))
+	| join(" ")
+}}
 
 ENV PHP_VERSION {{ .version }}
 ENV PHP_URL="{{ .url }}" PHP_ASC_URL="{{ .ascUrl // "" }}"

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,6 @@
 {
   "7.3": {
     "ascUrl": "https://www.php.net/distributions/php-7.3.33.tar.xz.asc",
-    "gpgKeys": "CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D",
     "sha256": "166eaccde933381da9516a2b70ad0f447d7cec4b603d07b9a916032b215b90cc",
     "url": "https://www.php.net/distributions/php-7.3.33.tar.xz",
     "variants": [
@@ -25,7 +24,6 @@
   "7.3-rc": null,
   "7.4": {
     "ascUrl": "https://www.php.net/distributions/php-7.4.27.tar.xz.asc",
-    "gpgKeys": "42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312",
     "sha256": "3f8b937310f155822752229c2c2feb8cc2621e25a728e7b94d0d74c128c43d0c",
     "url": "https://www.php.net/distributions/php-7.4.27.tar.xz",
     "variants": [
@@ -49,7 +47,6 @@
   "7.4-rc": null,
   "8.0": {
     "ascUrl": "https://www.php.net/distributions/php-8.0.15.tar.xz.asc",
-    "gpgKeys": "1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F",
     "sha256": "5f33544061d37d805a2a9ce791f081ef08a7155bd7ba2362e69bba2d06b0f8b2",
     "url": "https://www.php.net/distributions/php-8.0.15.tar.xz",
     "variants": [
@@ -71,7 +68,6 @@
   "8.0-rc": null,
   "8.1": {
     "ascUrl": "https://www.php.net/distributions/php-8.1.2.tar.xz.asc",
-    "gpgKeys": "528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD",
     "sha256": "6b448242fd360c1a9f265b7263abf3da25d28f2b2b0f5465533b69be51a391dd",
     "url": "https://www.php.net/distributions/php-8.1.2.tar.xz",
     "variants": [

--- a/versions.sh
+++ b/versions.sh
@@ -1,36 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# https://www.php.net/gpg-keys.php
-declare -A gpgKeys=(
-	# https://wiki.php.net/todo/php81
-	# krakjoe & ramsey & patrickallaert
-	# https://www.php.net/gpg-keys.php#gpg-8.1
-	[8.1]='528995BFEDFBA7191D46839EF9BA0ADA31CBD89E 39B641343D8C104B2B146DC3F9C39DC0B9698544 F1F692238FBC1666E5A5CCD4199F9DFEF6FFBAFD'
-
-	# https://wiki.php.net/todo/php80
-	# pollita & carusogabriel
-	# https://www.php.net/gpg-keys.php#gpg-8.0
-	[8.0]='1729F83938DA44E27BA0F4D3DBDB397470D12172 BFDDD28642824F8118EF77909B67A5C12229118F'
-
-	# https://wiki.php.net/todo/php74
-	# petk & derick
-	# https://www.php.net/gpg-keys.php#gpg-7.4
-	[7.4]='42670A7FE4D0441C8E4632349E4FDC074A4EF02D 5A52880781F755608BF815FC910DEB46F53EA312'
-
-	# https://wiki.php.net/todo/php73
-	# cmb & stas
-	# https://www.php.net/gpg-keys.php#gpg-7.3
-	[7.3]='CBAF69F173A0FEA4B537F470D66C9593118BCCB6 F38252826ACD957EF380D39F2F7956BC5DA04B5D'
-
-	# https://wiki.php.net/todo/php72
-	# pollita & remi
-	# https://www.php.net/downloads.php#gpg-7.2
-	# https://www.php.net/gpg-keys.php#gpg-7.2
-	[7.2]='1729F83938DA44E27BA0F4D3DBDB397470D12172 B1B44D8F021E4E2D6021E995DC9FF8D3EE5AF27F'
-)
-# see https://www.php.net/downloads.php
-
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=( "$@" )
@@ -102,14 +72,6 @@ for version in "${versions[@]}"; do
 	ascUrl="${possi[2]}"
 	sha256="${possi[3]}"
 
-	gpgKey="${gpgKeys[$rcVersion]:-}"
-	if [ -z "$gpgKey" ]; then
-		echo >&2 "ERROR: missing GPG key fingerprint for $version"
-		echo >&2 "  try looking on https://www.php.net/downloads.php#gpg-$rcVersion"
-		echo >&2 "  (and update 'gpgKeys' array in '$BASH_SOURCE')"
-		exit 1
-	fi
-
 	if ! wget -q --spider "$url"; then
 		echo >&2 "error: '$url' appears to be missing"
 		exit 1
@@ -144,7 +106,7 @@ for version in "${versions[@]}"; do
 
 	echo "$version: $fullVersion"
 
-	export fullVersion url ascUrl sha256 gpgKey
+	export fullVersion url ascUrl sha256
 	json="$(
 		jq <<<"$json" -c \
 			--argjson variants "$variants" \
@@ -153,7 +115,6 @@ for version in "${versions[@]}"; do
 				url: env.url,
 				ascUrl: env.ascUrl,
 				sha256: env.sha256,
-				gpgKeys: env.gpgKey,
 				variants: $variants,
 			}'
 	)"


### PR DESCRIPTION
They don't change within a release very often, so it doesn't feel "correct" to embed them in the block of more dynamic information we embed in `versions.json` (and IMO we get slightly better syntax this way).