### PR TITLE
Explicitly enable phpdbg in CLI images and *disable* it in all others

### DIFF
--- a/7.3/alpine3.14/cli/Dockerfile
+++ b/7.3/alpine3.14/cli/Dockerfile
@@ -143,6 +143,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/7.3/alpine3.14/fpm/Dockerfile
+++ b/7.3/alpine3.14/fpm/Dockerfile
@@ -143,6 +143,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/7.3/alpine3.14/zts/Dockerfile
+++ b/7.3/alpine3.14/zts/Dockerfile
@@ -143,6 +143,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/7.3/alpine3.15/cli/Dockerfile
+++ b/7.3/alpine3.15/cli/Dockerfile
@@ -143,6 +143,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/7.3/alpine3.15/fpm/Dockerfile
+++ b/7.3/alpine3.15/fpm/Dockerfile
@@ -143,6 +143,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/7.3/alpine3.15/zts/Dockerfile
+++ b/7.3/alpine3.15/zts/Dockerfile
@@ -143,6 +143,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \

--- a/7.3/bullseye/apache/Dockerfile
+++ b/7.3/bullseye/apache/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/bullseye/cli/Dockerfile
+++ b/7.3/bullseye/cli/Dockerfile
@@ -158,6 +158,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/bullseye/fpm/Dockerfile
+++ b/7.3/bullseye/fpm/Dockerfile
@@ -158,6 +158,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/bullseye/zts/Dockerfile
+++ b/7.3/bullseye/zts/Dockerfile
@@ -158,6 +158,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/buster/apache/Dockerfile
+++ b/7.3/buster/apache/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/buster/cli/Dockerfile
+++ b/7.3/buster/cli/Dockerfile
@@ -158,6 +158,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/buster/fpm/Dockerfile
+++ b/7.3/buster/fpm/Dockerfile
@@ -158,6 +158,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.3/buster/zts/Dockerfile
+++ b/7.3/buster/zts/Dockerfile
@@ -158,6 +158,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-gnu' && echo '--without-pcre-jit') \

--- a/7.4/alpine3.14/cli/Dockerfile
+++ b/7.4/alpine3.14/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/alpine3.14/fpm/Dockerfile
+++ b/7.4/alpine3.14/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/alpine3.14/zts/Dockerfile
+++ b/7.4/alpine3.14/zts/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/alpine3.15/cli/Dockerfile
+++ b/7.4/alpine3.15/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/alpine3.15/fpm/Dockerfile
+++ b/7.4/alpine3.15/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/alpine3.15/zts/Dockerfile
+++ b/7.4/alpine3.15/zts/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/bullseye/apache/Dockerfile
+++ b/7.4/bullseye/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/bullseye/cli/Dockerfile
+++ b/7.4/bullseye/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/bullseye/fpm/Dockerfile
+++ b/7.4/bullseye/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/bullseye/zts/Dockerfile
+++ b/7.4/bullseye/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/alpine3.14/cli/Dockerfile
+++ b/8.0-rc/alpine3.14/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/alpine3.14/fpm/Dockerfile
+++ b/8.0-rc/alpine3.14/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/alpine3.15/cli/Dockerfile
+++ b/8.0-rc/alpine3.15/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/alpine3.15/fpm/Dockerfile
+++ b/8.0-rc/alpine3.15/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/bullseye/apache/Dockerfile
+++ b/8.0-rc/bullseye/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/bullseye/cli/Dockerfile
+++ b/8.0-rc/bullseye/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/bullseye/fpm/Dockerfile
+++ b/8.0-rc/bullseye/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/bullseye/zts/Dockerfile
+++ b/8.0-rc/bullseye/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/buster/apache/Dockerfile
+++ b/8.0-rc/buster/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/buster/cli/Dockerfile
+++ b/8.0-rc/buster/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0-rc/buster/zts/Dockerfile
+++ b/8.0-rc/buster/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/alpine3.14/cli/Dockerfile
+++ b/8.0/alpine3.14/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/alpine3.14/fpm/Dockerfile
+++ b/8.0/alpine3.14/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/alpine3.15/cli/Dockerfile
+++ b/8.0/alpine3.15/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/alpine3.15/fpm/Dockerfile
+++ b/8.0/alpine3.15/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/bullseye/apache/Dockerfile
+++ b/8.0/bullseye/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/bullseye/cli/Dockerfile
+++ b/8.0/bullseye/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/bullseye/fpm/Dockerfile
+++ b/8.0/bullseye/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/bullseye/zts/Dockerfile
+++ b/8.0/bullseye/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/buster/apache/Dockerfile
+++ b/8.0/buster/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/buster/cli/Dockerfile
+++ b/8.0/buster/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/buster/fpm/Dockerfile
+++ b/8.0/buster/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.0/buster/zts/Dockerfile
+++ b/8.0/buster/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/alpine3.14/cli/Dockerfile
+++ b/8.1/alpine3.14/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/alpine3.14/fpm/Dockerfile
+++ b/8.1/alpine3.14/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/alpine3.15/cli/Dockerfile
+++ b/8.1/alpine3.15/cli/Dockerfile
@@ -145,6 +145,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/alpine3.15/fpm/Dockerfile
+++ b/8.1/alpine3.15/fpm/Dockerfile
@@ -145,6 +145,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/bullseye/apache/Dockerfile
+++ b/8.1/bullseye/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/bullseye/cli/Dockerfile
+++ b/8.1/bullseye/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/buster/apache/Dockerfile
+++ b/8.1/buster/apache/Dockerfile
@@ -218,6 +218,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/buster/cli/Dockerfile
+++ b/8.1/buster/cli/Dockerfile
@@ -159,6 +159,10 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/buster/fpm/Dockerfile
+++ b/8.1/buster/fpm/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/8.1/buster/zts/Dockerfile
+++ b/8.1/buster/zts/Dockerfile
@@ -159,6 +159,9 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+		\
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -333,6 +333,15 @@ RUN set -eux; \
 		--with-readline \
 		--with-zlib \
 		\
+{{ if env.variant == "cli" then ( -}}
+# https://github.com/docker-library/php/pull/1259
+		--enable-phpdbg \
+		--enable-phpdbg-readline \
+{{ ) else ( -}}
+# https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 ("phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.")
+		--disable-phpdbg \
+{{ ) end -}}
+		\
 {{ if (.version | version_id) >= ("7.4" | version_id) then ( -}}
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \


### PR DESCRIPTION
Closes #1257

See also https://github.com/bwoebi/phpdbg-docs/issues/1#issuecomment-163872806 (which is a comment from a PHP release manager :heart:):

> phpdbg is primarily a CLI debugger, and is not suitable for debugging an fpm stack.

This should save ~13MB on all non-CLI variants (and no increase for CLI because it already included it :joy: :innocent:).