### PR TITLE
Keep default log_limit value

### DIFF
--- a/8.1/alpine3.15/fpm/Dockerfile
+++ b/8.1/alpine3.15/fpm/Dockerfile
@@ -223,7 +223,6 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'error_log = /proc/self/fd/2'; \
-		echo; echo '; https://github.com/docker-library/php/pull/725#issuecomment-443540114'; echo 'log_limit = 8192'; \
 		echo; \
 		echo '[www]'; \
 		echo '; if we send this to /proc/self/fd/1, it never appears'; \


### PR DESCRIPTION
PHP default configuration says that it should be 1024: https://www.php.net/manual/en/install.fpm.configuration.php

<img width="1039" alt="image" src="https://user-images.githubusercontent.com/6154604/157437539-6ec36880-fd35-4052-9f15-a2d4370cc39e.png">

I think that we need to make things consistent as close as possible to defaults coming from PHP itself, as these are PHP base images.

**Specifying different `log_limit` should be a project-specific thing, and it should not be specified in the base image.**

I see that changes were introduced in https://github.com/docker-library/php/pull/725#issuecomment-443540114.
