### PR TITLE
Update iconv extension to be shared, so it can be disabled if necessary

### DIFF
--- a/7.3/alpine3.14/cli/Dockerfile
+++ b/7.3/alpine3.14/cli/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -191,6 +192,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.3/alpine3.14/fpm/Dockerfile
+++ b/7.3/alpine3.14/fpm/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/7.3/alpine3.14/zts/Dockerfile
+++ b/7.3/alpine3.14/zts/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -194,6 +195,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.3/alpine3.15/cli/Dockerfile
+++ b/7.3/alpine3.15/cli/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -191,6 +192,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.3/alpine3.15/fpm/Dockerfile
+++ b/7.3/alpine3.15/fpm/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/7.3/alpine3.15/zts/Dockerfile
+++ b/7.3/alpine3.15/zts/Dockerfile
@@ -139,6 +139,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -194,6 +195,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.3/bullseye/apache/Dockerfile
+++ b/7.3/bullseye/apache/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -273,6 +274,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/bullseye/cli/Dockerfile
+++ b/7.3/bullseye/cli/Dockerfile
@@ -154,6 +154,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -214,6 +215,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/bullseye/fpm/Dockerfile
+++ b/7.3/bullseye/fpm/Dockerfile
@@ -154,6 +154,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -216,6 +217,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/bullseye/zts/Dockerfile
+++ b/7.3/bullseye/zts/Dockerfile
@@ -154,6 +154,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -217,6 +218,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/buster/apache/Dockerfile
+++ b/7.3/buster/apache/Dockerfile
@@ -213,6 +213,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -273,6 +274,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/buster/cli/Dockerfile
+++ b/7.3/buster/cli/Dockerfile
@@ -154,6 +154,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -214,6 +215,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/buster/fpm/Dockerfile
+++ b/7.3/buster/fpm/Dockerfile
@@ -154,6 +154,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -216,6 +217,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.3/buster/zts/Dockerfile
+++ b/7.3/buster/zts/Dockerfile
@@ -154,6 +154,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -217,6 +218,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 # temporary "freetype-config" workaround for https://github.com/docker-library/php/issues/865 (https://bugs.php.net/bug.php?id=76324)
 RUN { echo '#!/bin/sh'; echo 'exec pkg-config "$@" freetype2'; } > /usr/local/bin/freetype-config && chmod +x /usr/local/bin/freetype-config

--- a/7.4/alpine3.14/cli/Dockerfile
+++ b/7.4/alpine3.14/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/alpine3.14/fpm/Dockerfile
+++ b/7.4/alpine3.14/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/7.4/alpine3.14/zts/Dockerfile
+++ b/7.4/alpine3.14/zts/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -199,6 +200,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/alpine3.15/cli/Dockerfile
+++ b/7.4/alpine3.15/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/alpine3.15/fpm/Dockerfile
+++ b/7.4/alpine3.15/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/7.4/alpine3.15/zts/Dockerfile
+++ b/7.4/alpine3.15/zts/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -199,6 +200,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/bullseye/apache/Dockerfile
+++ b/7.4/bullseye/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/7.4/bullseye/cli/Dockerfile
+++ b/7.4/bullseye/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/bullseye/fpm/Dockerfile
+++ b/7.4/bullseye/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/7.4/bullseye/zts/Dockerfile
+++ b/7.4/bullseye/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0-rc/alpine3.14/cli/Dockerfile
+++ b/8.0-rc/alpine3.14/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0-rc/alpine3.14/fpm/Dockerfile
+++ b/8.0-rc/alpine3.14/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0-rc/alpine3.15/cli/Dockerfile
+++ b/8.0-rc/alpine3.15/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0-rc/alpine3.15/fpm/Dockerfile
+++ b/8.0-rc/alpine3.15/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0-rc/bullseye/apache/Dockerfile
+++ b/8.0-rc/bullseye/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.0-rc/bullseye/cli/Dockerfile
+++ b/8.0-rc/bullseye/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0-rc/bullseye/fpm/Dockerfile
+++ b/8.0-rc/bullseye/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0-rc/bullseye/zts/Dockerfile
+++ b/8.0-rc/bullseye/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0-rc/buster/apache/Dockerfile
+++ b/8.0-rc/buster/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.0-rc/buster/cli/Dockerfile
+++ b/8.0-rc/buster/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0-rc/buster/zts/Dockerfile
+++ b/8.0-rc/buster/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0/alpine3.14/cli/Dockerfile
+++ b/8.0/alpine3.14/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0/alpine3.14/fpm/Dockerfile
+++ b/8.0/alpine3.14/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0/alpine3.15/cli/Dockerfile
+++ b/8.0/alpine3.15/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0/alpine3.15/fpm/Dockerfile
+++ b/8.0/alpine3.15/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0/bullseye/apache/Dockerfile
+++ b/8.0/bullseye/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.0/bullseye/cli/Dockerfile
+++ b/8.0/bullseye/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0/bullseye/fpm/Dockerfile
+++ b/8.0/bullseye/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0/bullseye/zts/Dockerfile
+++ b/8.0/bullseye/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0/buster/apache/Dockerfile
+++ b/8.0/buster/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.0/buster/cli/Dockerfile
+++ b/8.0/buster/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.0/buster/fpm/Dockerfile
+++ b/8.0/buster/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.0/buster/zts/Dockerfile
+++ b/8.0/buster/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1-rc/alpine3.14/cli/Dockerfile
+++ b/8.1-rc/alpine3.14/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1-rc/alpine3.14/fpm/Dockerfile
+++ b/8.1-rc/alpine3.14/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1-rc/alpine3.15/cli/Dockerfile
+++ b/8.1-rc/alpine3.15/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1-rc/alpine3.15/fpm/Dockerfile
+++ b/8.1-rc/alpine3.15/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1-rc/bullseye/apache/Dockerfile
+++ b/8.1-rc/bullseye/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.1-rc/bullseye/cli/Dockerfile
+++ b/8.1-rc/bullseye/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1-rc/bullseye/fpm/Dockerfile
+++ b/8.1-rc/bullseye/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1-rc/bullseye/zts/Dockerfile
+++ b/8.1-rc/bullseye/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1-rc/buster/apache/Dockerfile
+++ b/8.1-rc/buster/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.1-rc/buster/cli/Dockerfile
+++ b/8.1-rc/buster/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1-rc/buster/fpm/Dockerfile
+++ b/8.1-rc/buster/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1-rc/buster/zts/Dockerfile
+++ b/8.1-rc/buster/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1/alpine3.14/cli/Dockerfile
+++ b/8.1/alpine3.14/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1/alpine3.14/fpm/Dockerfile
+++ b/8.1/alpine3.14/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1/alpine3.15/cli/Dockerfile
+++ b/8.1/alpine3.15/cli/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -196,6 +197,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1/alpine3.15/fpm/Dockerfile
+++ b/8.1/alpine3.15/fpm/Dockerfile
@@ -141,6 +141,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -201,6 +202,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1/bullseye/apache/Dockerfile
+++ b/8.1/bullseye/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.1/bullseye/cli/Dockerfile
+++ b/8.1/bullseye/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1/buster/apache/Dockerfile
+++ b/8.1/buster/apache/Dockerfile
@@ -214,6 +214,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -277,6 +278,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 # https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop

--- a/8.1/buster/cli/Dockerfile
+++ b/8.1/buster/cli/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -218,6 +219,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/8.1/buster/fpm/Dockerfile
+++ b/8.1/buster/fpm/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -220,6 +221,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html

--- a/8.1/buster/zts/Dockerfile
+++ b/8.1/buster/zts/Dockerfile
@@ -155,6 +155,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -221,6 +222,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 ENTRYPOINT ["docker-php-entrypoint"]
 CMD ["php", "-a"]

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -329,6 +329,7 @@ RUN set -eux; \
 		--with-sqlite3=/usr \
 		\
 		--with-curl \
+		--with-iconv=shared \
 		--with-openssl \
 		--with-readline \
 		--with-zlib \
@@ -438,6 +439,9 @@ COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
+
+# iconv was built as a shared module (so it can be disabled later if desired)
+RUN docker-php-ext-enable iconv
 
 {{
 	# https://github.com/docker-library/php/issues/865


### PR DESCRIPTION
This compiles the iconv extension as a shared object so it may be disabled if necessary.

Disabling this extension is desired when using symfony's polyfill-iconv library.