### PR TITLE
Fix conditional "strip" based on "ZEND_DEBUG_BUILD"

### DIFF
--- a/7.4/alpine3.14/cli/Dockerfile
+++ b/7.4/alpine3.14/cli/Dockerfile
@@ -166,14 +166,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/alpine3.14/cli/docker-php-ext-install
+++ b/7.4/alpine3.14/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/alpine3.14/fpm/Dockerfile
+++ b/7.4/alpine3.14/fpm/Dockerfile
@@ -171,14 +171,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/alpine3.14/fpm/docker-php-ext-install
+++ b/7.4/alpine3.14/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/alpine3.14/zts/Dockerfile
+++ b/7.4/alpine3.14/zts/Dockerfile
@@ -169,14 +169,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/alpine3.14/zts/docker-php-ext-install
+++ b/7.4/alpine3.14/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/alpine3.15/cli/Dockerfile
+++ b/7.4/alpine3.15/cli/Dockerfile
@@ -166,14 +166,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/alpine3.15/cli/docker-php-ext-install
+++ b/7.4/alpine3.15/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/alpine3.15/fpm/Dockerfile
+++ b/7.4/alpine3.15/fpm/Dockerfile
@@ -171,14 +171,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/alpine3.15/fpm/docker-php-ext-install
+++ b/7.4/alpine3.15/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/alpine3.15/zts/Dockerfile
+++ b/7.4/alpine3.15/zts/Dockerfile
@@ -169,14 +169,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/alpine3.15/zts/docker-php-ext-install
+++ b/7.4/alpine3.15/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/bullseye/apache/Dockerfile
+++ b/7.4/bullseye/apache/Dockerfile
@@ -237,14 +237,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/bullseye/apache/docker-php-ext-install
+++ b/7.4/bullseye/apache/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/bullseye/cli/Dockerfile
+++ b/7.4/bullseye/cli/Dockerfile
@@ -178,14 +178,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/bullseye/cli/docker-php-ext-install
+++ b/7.4/bullseye/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/bullseye/fpm/Dockerfile
+++ b/7.4/bullseye/fpm/Dockerfile
@@ -180,14 +180,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/bullseye/fpm/docker-php-ext-install
+++ b/7.4/bullseye/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/bullseye/zts/Dockerfile
+++ b/7.4/bullseye/zts/Dockerfile
@@ -181,14 +181,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/bullseye/zts/docker-php-ext-install
+++ b/7.4/bullseye/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -237,14 +237,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/buster/apache/docker-php-ext-install
+++ b/7.4/buster/apache/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -178,14 +178,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/buster/cli/docker-php-ext-install
+++ b/7.4/buster/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -180,14 +180,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/buster/fpm/docker-php-ext-install
+++ b/7.4/buster/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -181,14 +181,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/7.4/buster/zts/docker-php-ext-install
+++ b/7.4/buster/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/alpine3.14/cli/Dockerfile
+++ b/8.0/alpine3.14/cli/Dockerfile
@@ -164,14 +164,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/alpine3.14/cli/docker-php-ext-install
+++ b/8.0/alpine3.14/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/alpine3.14/fpm/Dockerfile
+++ b/8.0/alpine3.14/fpm/Dockerfile
@@ -169,14 +169,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/alpine3.14/fpm/docker-php-ext-install
+++ b/8.0/alpine3.14/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/alpine3.15/cli/Dockerfile
+++ b/8.0/alpine3.15/cli/Dockerfile
@@ -164,14 +164,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/alpine3.15/cli/docker-php-ext-install
+++ b/8.0/alpine3.15/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/alpine3.15/fpm/Dockerfile
+++ b/8.0/alpine3.15/fpm/Dockerfile
@@ -169,14 +169,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/alpine3.15/fpm/docker-php-ext-install
+++ b/8.0/alpine3.15/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/bullseye/apache/Dockerfile
+++ b/8.0/bullseye/apache/Dockerfile
@@ -237,14 +237,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/bullseye/apache/docker-php-ext-install
+++ b/8.0/bullseye/apache/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/bullseye/cli/Dockerfile
+++ b/8.0/bullseye/cli/Dockerfile
@@ -178,14 +178,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/bullseye/cli/docker-php-ext-install
+++ b/8.0/bullseye/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/bullseye/fpm/Dockerfile
+++ b/8.0/bullseye/fpm/Dockerfile
@@ -180,14 +180,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/bullseye/fpm/docker-php-ext-install
+++ b/8.0/bullseye/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/bullseye/zts/Dockerfile
+++ b/8.0/bullseye/zts/Dockerfile
@@ -181,14 +181,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/bullseye/zts/docker-php-ext-install
+++ b/8.0/bullseye/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/buster/apache/Dockerfile
+++ b/8.0/buster/apache/Dockerfile
@@ -237,14 +237,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/buster/apache/docker-php-ext-install
+++ b/8.0/buster/apache/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/buster/cli/Dockerfile
+++ b/8.0/buster/cli/Dockerfile
@@ -178,14 +178,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/buster/cli/docker-php-ext-install
+++ b/8.0/buster/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/buster/fpm/Dockerfile
+++ b/8.0/buster/fpm/Dockerfile
@@ -180,14 +180,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/buster/fpm/docker-php-ext-install
+++ b/8.0/buster/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.0/buster/zts/Dockerfile
+++ b/8.0/buster/zts/Dockerfile
@@ -181,14 +181,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.0/buster/zts/docker-php-ext-install
+++ b/8.0/buster/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/alpine3.14/cli/Dockerfile
+++ b/8.1/alpine3.14/cli/Dockerfile
@@ -164,14 +164,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/alpine3.14/cli/docker-php-ext-install
+++ b/8.1/alpine3.14/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/alpine3.14/fpm/Dockerfile
+++ b/8.1/alpine3.14/fpm/Dockerfile
@@ -169,14 +169,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/alpine3.14/fpm/docker-php-ext-install
+++ b/8.1/alpine3.14/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/alpine3.15/cli/Dockerfile
+++ b/8.1/alpine3.15/cli/Dockerfile
@@ -164,14 +164,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/alpine3.15/cli/docker-php-ext-install
+++ b/8.1/alpine3.15/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/alpine3.15/fpm/Dockerfile
+++ b/8.1/alpine3.15/fpm/Dockerfile
@@ -169,14 +169,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/alpine3.15/fpm/docker-php-ext-install
+++ b/8.1/alpine3.15/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/bullseye/apache/Dockerfile
+++ b/8.1/bullseye/apache/Dockerfile
@@ -237,14 +237,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/bullseye/apache/docker-php-ext-install
+++ b/8.1/bullseye/apache/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/bullseye/cli/Dockerfile
+++ b/8.1/bullseye/cli/Dockerfile
@@ -178,14 +178,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/bullseye/cli/docker-php-ext-install
+++ b/8.1/bullseye/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -180,14 +180,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/bullseye/fpm/docker-php-ext-install
+++ b/8.1/bullseye/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -181,14 +181,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/bullseye/zts/docker-php-ext-install
+++ b/8.1/bullseye/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/buster/apache/Dockerfile
+++ b/8.1/buster/apache/Dockerfile
@@ -237,14 +237,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/buster/apache/docker-php-ext-install
+++ b/8.1/buster/apache/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/buster/cli/Dockerfile
+++ b/8.1/buster/cli/Dockerfile
@@ -178,14 +178,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/buster/cli/docker-php-ext-install
+++ b/8.1/buster/cli/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/buster/fpm/Dockerfile
+++ b/8.1/buster/fpm/Dockerfile
@@ -180,14 +180,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/buster/fpm/docker-php-ext-install
+++ b/8.1/buster/fpm/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/8.1/buster/zts/Dockerfile
+++ b/8.1/buster/zts/Dockerfile
@@ -181,14 +181,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/8.1/buster/zts/docker-php-ext-install
+++ b/8.1/buster/zts/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -389,14 +389,18 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
-		/usr/local \
-		-type f \
-		-perm '/0111' \
-		-exec sh -euxc ' \
-			strip --strip-all "$@" || : \
-		' -- '{}' + \
-	; \
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then \
+		# only "strip" binaries if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+		find \
+			/usr/local \
+			-type f \
+			-perm '/0111' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || : \
+			' -- '{}' +; \
+	fi; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -112,7 +112,6 @@ for ext in $exts; do
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
 		# https://github.com/docker-library/php/issues/1268
-
 		find modules \
 			-maxdepth 1 \
 			-name '*.so' \


### PR DESCRIPTION
`strip --strip-all` is present on two places, in https://github.com/docker-library/php/pull/1278, it was made conditional for modules, this PR makes it conditional also for the main binaries