### PR TITLE
Add native support for ext disable/reenable

### DIFF
--- a/7.4/alpine3.14/cli/docker-php-ext-enable
+++ b/7.4/alpine3.14/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/alpine3.14/fpm/docker-php-ext-enable
+++ b/7.4/alpine3.14/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/alpine3.14/zts/docker-php-ext-enable
+++ b/7.4/alpine3.14/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/alpine3.15/cli/docker-php-ext-enable
+++ b/7.4/alpine3.15/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/alpine3.15/fpm/docker-php-ext-enable
+++ b/7.4/alpine3.15/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/alpine3.15/zts/docker-php-ext-enable
+++ b/7.4/alpine3.15/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/bullseye/apache/docker-php-ext-enable
+++ b/7.4/bullseye/apache/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/bullseye/cli/docker-php-ext-enable
+++ b/7.4/bullseye/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/bullseye/fpm/docker-php-ext-enable
+++ b/7.4/bullseye/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/bullseye/zts/docker-php-ext-enable
+++ b/7.4/bullseye/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/buster/apache/docker-php-ext-enable
+++ b/7.4/buster/apache/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/buster/cli/docker-php-ext-enable
+++ b/7.4/buster/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/buster/fpm/docker-php-ext-enable
+++ b/7.4/buster/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/7.4/buster/zts/docker-php-ext-enable
+++ b/7.4/buster/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/alpine3.14/cli/docker-php-ext-enable
+++ b/8.0/alpine3.14/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/alpine3.14/fpm/docker-php-ext-enable
+++ b/8.0/alpine3.14/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/alpine3.15/cli/docker-php-ext-enable
+++ b/8.0/alpine3.15/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/alpine3.15/fpm/docker-php-ext-enable
+++ b/8.0/alpine3.15/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/bullseye/apache/docker-php-ext-enable
+++ b/8.0/bullseye/apache/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/bullseye/cli/docker-php-ext-enable
+++ b/8.0/bullseye/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/bullseye/fpm/docker-php-ext-enable
+++ b/8.0/bullseye/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/bullseye/zts/docker-php-ext-enable
+++ b/8.0/bullseye/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/buster/apache/docker-php-ext-enable
+++ b/8.0/buster/apache/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/buster/cli/docker-php-ext-enable
+++ b/8.0/buster/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/buster/fpm/docker-php-ext-enable
+++ b/8.0/buster/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.0/buster/zts/docker-php-ext-enable
+++ b/8.0/buster/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/alpine3.14/cli/docker-php-ext-enable
+++ b/8.1/alpine3.14/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/alpine3.14/fpm/docker-php-ext-enable
+++ b/8.1/alpine3.14/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/alpine3.15/cli/docker-php-ext-enable
+++ b/8.1/alpine3.15/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/alpine3.15/fpm/docker-php-ext-enable
+++ b/8.1/alpine3.15/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/bullseye/apache/docker-php-ext-enable
+++ b/8.1/bullseye/apache/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/bullseye/cli/docker-php-ext-enable
+++ b/8.1/bullseye/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/bullseye/fpm/docker-php-ext-enable
+++ b/8.1/bullseye/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/bullseye/zts/docker-php-ext-enable
+++ b/8.1/bullseye/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/buster/apache/docker-php-ext-enable
+++ b/8.1/buster/apache/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/buster/cli/docker-php-ext-enable
+++ b/8.1/buster/cli/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/buster/fpm/docker-php-ext-enable
+++ b/8.1/buster/fpm/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/8.1/buster/zts/docker-php-ext-enable
+++ b/8.1/buster/zts/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 

--- a/docker-php-ext-enable
+++ b/docker-php-ext-enable
@@ -8,6 +8,7 @@ usage() {
 	echo "usage: $0 [options] module-name [module-name ...]"
 	echo "   ie: $0 gd mysqli"
 	echo "       $0 pdo pdo_mysql"
+	echo "       $0 --disable gd mysqli"
 	echo "       $0 --ini-name 0-apc.ini apcu apc"
 	echo
 	echo 'Possible values for module-name:'
@@ -22,15 +23,17 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
-opts="$(getopt -o 'h?' --long 'help,ini-name:' -- "$@" || { usage >&2 && false; })"
+opts="$(getopt -o 'h?' --long 'help,disable,ini-name:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
+isDisable=
 iniName=
 while true; do
 	flag="$1"
 	shift
 	case "$flag" in
 		--help|-h|'-?') usage && exit 0 ;;
+		--disable) isDisable=1 ;;
 		--ini-name) iniName="$1" && shift ;;
 		--) break ;;
 		*)
@@ -93,7 +96,7 @@ for module in $modules; do
 
 	ext="$(basename "$module")"
 	ext="${ext%.*}"
-	if php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
+	if [ -z "$isDisable" ] && php -d 'display_errors=stderr' -r 'exit(extension_loaded("'"$ext"'") ? 0 : 1);'; then
 		# this isn't perfect, but it's better than nothing
 		# (for example, 'opcache.so' presents inside PHP as 'Zend OPcache', not 'opcache')
 		echo >&2
@@ -111,8 +114,23 @@ for module in $modules; do
 			ini="$PHP_INI_DIR/conf.d/${iniName:-"docker-php-ext-$ext.ini"}"
 			;;
 	esac
-	if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
-		echo "$line" >> "$ini"
+
+	if [ -z "$isDisable" ]; then
+		if [ -f "$ini-disabled" ]; then
+			mv "$ini-disabled" "$ini"
+		else
+			if ! grep -qFx -e "$line" -e "$line.so" "$ini" 2>/dev/null; then
+				echo "$line" >> "$ini"
+			fi
+		fi
+	else
+		if ! [ -f "$ini" ]; then
+			echo >&2
+			echo >&2 "warning: $ext ($module) is not enabled!"
+			echo >&2
+			continue
+		fi
+		mv "$ini" "$ini-disabled"
 	fi
 done
 


### PR DESCRIPTION
Close https://github.com/docker-library/php/issues/1277

renaming `.ini` to `.ini-disabled` is safe, only `*.ini` files are scanned https://github.com/php/php-src/blob/ac1c2dcd6aef087cc87e55dd4d9e8a198bea1fb5/main/php_ini.c#L674

this native ext disable support maintain the original ext config for possible future ext (re)enable