### PR TITLE
Add build argument for debug image

### DIFF
--- a/7.4/alpine3.14/cli/Dockerfile
+++ b/7.4/alpine3.14/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -162,6 +165,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/alpine3.14/fpm/Dockerfile
+++ b/7.4/alpine3.14/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -167,6 +170,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/alpine3.14/zts/Dockerfile
+++ b/7.4/alpine3.14/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-maintainer-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/alpine3.15/cli/Dockerfile
+++ b/7.4/alpine3.15/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -162,6 +165,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/alpine3.15/fpm/Dockerfile
+++ b/7.4/alpine3.15/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -167,6 +170,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/alpine3.15/zts/Dockerfile
+++ b/7.4/alpine3.15/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-maintainer-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/bullseye/apache/Dockerfile
+++ b/7.4/bullseye/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/bullseye/cli/Dockerfile
+++ b/7.4/bullseye/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/bullseye/fpm/Dockerfile
+++ b/7.4/bullseye/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/bullseye/zts/Dockerfile
+++ b/7.4/bullseye/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-maintainer-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/buster/apache/Dockerfile
+++ b/7.4/buster/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/buster/cli/Dockerfile
+++ b/7.4/buster/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-maintainer-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.14/cli/Dockerfile
+++ b/8.0/alpine3.14/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -160,6 +163,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.14/fpm/Dockerfile
+++ b/8.0/alpine3.14/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.15/cli/Dockerfile
+++ b/8.0/alpine3.15/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -160,6 +163,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.15/fpm/Dockerfile
+++ b/8.0/alpine3.15/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/bullseye/apache/Dockerfile
+++ b/8.0/bullseye/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/bullseye/cli/Dockerfile
+++ b/8.0/bullseye/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/bullseye/fpm/Dockerfile
+++ b/8.0/bullseye/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/bullseye/zts/Dockerfile
+++ b/8.0/bullseye/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/buster/apache/Dockerfile
+++ b/8.0/buster/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/buster/cli/Dockerfile
+++ b/8.0/buster/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/buster/fpm/Dockerfile
+++ b/8.0/buster/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/buster/zts/Dockerfile
+++ b/8.0/buster/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/alpine3.14/cli/Dockerfile
+++ b/8.1-rc/alpine3.14/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -160,6 +163,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/alpine3.14/fpm/Dockerfile
+++ b/8.1-rc/alpine3.14/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/alpine3.15/cli/Dockerfile
+++ b/8.1-rc/alpine3.15/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -160,6 +163,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/alpine3.15/fpm/Dockerfile
+++ b/8.1-rc/alpine3.15/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/bullseye/apache/Dockerfile
+++ b/8.1-rc/bullseye/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/bullseye/cli/Dockerfile
+++ b/8.1-rc/bullseye/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/bullseye/fpm/Dockerfile
+++ b/8.1-rc/bullseye/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/bullseye/zts/Dockerfile
+++ b/8.1-rc/bullseye/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/buster/apache/Dockerfile
+++ b/8.1-rc/buster/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/buster/cli/Dockerfile
+++ b/8.1-rc/buster/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/buster/fpm/Dockerfile
+++ b/8.1-rc/buster/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1-rc/buster/zts/Dockerfile
+++ b/8.1-rc/buster/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.14/cli/Dockerfile
+++ b/8.1/alpine3.14/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -160,6 +163,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.14/fpm/Dockerfile
+++ b/8.1/alpine3.14/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.14
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.15/cli/Dockerfile
+++ b/8.1/alpine3.15/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -160,6 +163,7 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.15/fpm/Dockerfile
+++ b/8.1/alpine3.15/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM alpine:3.15
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # dependencies required for running "phpize"
 # these get automatically installed and removed by "docker-php-ext-*" (unless they're already installed)
 ENV PHPIZE_DEPS \
@@ -165,6 +168,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/bullseye/apache/Dockerfile
+++ b/8.1/bullseye/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/bullseye/cli/Dockerfile
+++ b/8.1/bullseye/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:bullseye-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/buster/apache/Dockerfile
+++ b/8.1/buster/apache/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -233,6 +236,7 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--with-apxs2 \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/buster/cli/Dockerfile
+++ b/8.1/buster/cli/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -174,6 +177,7 @@ RUN set -eux; \
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/buster/fpm/Dockerfile
+++ b/8.1/buster/fpm/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -176,6 +179,7 @@ RUN set -eux; \
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/buster/zts/Dockerfile
+++ b/8.1/buster/zts/Dockerfile
@@ -6,6 +6,9 @@
 
 FROM debian:buster-slim
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
 RUN set -eux; \
@@ -177,6 +180,7 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -393,7 +393,7 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	if [ -z "$DEBUG" ] ; find \
+	find \
 		/usr/local \
 		-type f \
 		-perm '/0111' \
@@ -401,7 +401,6 @@ RUN set -eux; \
 			strip --strip-all "$@" || : \
 		' -- '{}' + \
 	; \
-	fi ; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -15,6 +15,9 @@
 -}}
 FROM {{ env.from }}
 
+# Enables debug image when built with: --build-arg DEBUG=1
+ARG DEBUG
+
 {{ if is_alpine then "" else ( -}}
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
@@ -385,11 +388,12 @@ RUN set -eux; \
 		--enable-maintainer-zts \
 {{ ) end -}}
 {{ ) else "" end -}}
+		${DEBUG:+--enable-debug} \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
-	find \
+	if [ -z "$DEBUG" ] ; find \
 		/usr/local \
 		-type f \
 		-perm '/0111' \
@@ -397,6 +401,7 @@ RUN set -eux; \
 			strip --strip-all "$@" || : \
 		' -- '{}' + \
 	; \
+	fi ; \
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)


### PR DESCRIPTION
I understand that #879 likely won't be solved any time soon but I'd like to at least add a support for an ARG so that I can easily checkout this repository and build a debug image myself like this:

```
docker build --pull --no-cache 8.1/bullseye/cli --build-arg DEBUG=1
```

What do you think?

EDIT: Partially reverted. It is now meant to be used together with #1280. This way the condition added in 1280 makes more sense because it can be true without any modifications to the Dockerfile.