### PR TITLE
enable calendar-functions

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -321,6 +321,8 @@ RUN set -eux; \
 		--enable-ftp \
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
 		--enable-mbstring \
+# --enable calendaring functions as there is no other way to enable those functions except when compiling PHP
+                --enable-calendar
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
 # https://wiki.php.net/rfc/argon2_password_hash


### PR DESCRIPTION
The calendaring functions (like `easter_date` or `juliantojd`) need to be enabled at compile-time. For calendaring libraries those are an absolute must so it would be a good idea to actually have them available in a general-usage distribution