### PR TITLE
[RFC] Add PHP_PM_MAX_CHILDREN

### DIFF
--- a/7.4/alpine3.15/fpm/Dockerfile
+++ b/7.4/alpine3.15/fpm/Dockerfile
@@ -212,6 +212,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -248,6 +250,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/7.4/alpine3.16/fpm/Dockerfile
+++ b/7.4/alpine3.16/fpm/Dockerfile
@@ -212,6 +212,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -248,6 +250,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/7.4/bullseye/fpm/Dockerfile
+++ b/7.4/bullseye/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/7.4/buster/fpm/Dockerfile
+++ b/7.4/buster/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0-rc/alpine3.15/fpm/Dockerfile
+++ b/8.0-rc/alpine3.15/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0-rc/alpine3.16/fpm/Dockerfile
+++ b/8.0-rc/alpine3.16/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0-rc/bullseye/fpm/Dockerfile
+++ b/8.0-rc/bullseye/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0/alpine3.15/fpm/Dockerfile
+++ b/8.0/alpine3.15/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0/alpine3.16/fpm/Dockerfile
+++ b/8.0/alpine3.16/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0/bullseye/fpm/Dockerfile
+++ b/8.0/bullseye/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.0/buster/fpm/Dockerfile
+++ b/8.0/buster/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.1/alpine3.15/fpm/Dockerfile
+++ b/8.1/alpine3.15/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.1/alpine3.16/fpm/Dockerfile
+++ b/8.1/alpine3.16/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.1/buster/fpm/Dockerfile
+++ b/8.1/buster/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.2-rc/alpine3.15/fpm/Dockerfile
+++ b/8.2-rc/alpine3.15/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.2-rc/alpine3.16/fpm/Dockerfile
+++ b/8.2-rc/alpine3.16/fpm/Dockerfile
@@ -210,6 +210,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -246,6 +248,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.2-rc/bullseye/fpm/Dockerfile
+++ b/8.2-rc/bullseye/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/8.2-rc/buster/fpm/Dockerfile
+++ b/8.2-rc/buster/fpm/Dockerfile
@@ -225,6 +225,8 @@ RUN docker-php-ext-enable sodium
 ENTRYPOINT ["docker-php-entrypoint"]
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -261,6 +263,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -474,6 +474,8 @@ EXPOSE 80
 {{ ) elif env.variant == "fpm" then ( -}}
 WORKDIR /var/www/html
 
+ENV PHP_PM_MAX_CHILDREN 5
+
 RUN set -eux; \
 	cd /usr/local/etc; \
 	if [ -d php-fpm.d ]; then \
@@ -510,6 +512,8 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+		echo; \
+		echo 'pm.max_children = ${PHP_PM_MAX_CHILDREN}'; \
 	} | tee php-fpm.d/zz-docker.conf
 
 # Override stop signal to stop process gracefully


### PR DESCRIPTION
The default of `5` is not meaningful for productive workloads (see https://github.com/nextcloud/docker/pull/1766). Since this affects all PHP based containers I'd suggest to introduce this config in the base image.