### PR TITLE
fix: disable Zend Signals for ZTS builds

### DIFF
--- a/7.4/alpine3.15/zts/Dockerfile
+++ b/7.4/alpine3.15/zts/Dockerfile
@@ -165,6 +165,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-maintainer-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/alpine3.16/zts/Dockerfile
+++ b/7.4/alpine3.16/zts/Dockerfile
@@ -165,6 +165,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-maintainer-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/bullseye/zts/Dockerfile
+++ b/7.4/bullseye/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-maintainer-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/7.4/buster/zts/Dockerfile
+++ b/7.4/buster/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-maintainer-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.15/zts/Dockerfile
+++ b/8.0/alpine3.15/zts/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.16/zts/Dockerfile
+++ b/8.0/alpine3.16/zts/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/bullseye/zts/Dockerfile
+++ b/8.0/bullseye/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/buster/zts/Dockerfile
+++ b/8.0/buster/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.15/zts/Dockerfile
+++ b/8.1/alpine3.15/zts/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.16/zts/Dockerfile
+++ b/8.1/alpine3.16/zts/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/buster/zts/Dockerfile
+++ b/8.1/buster/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2-rc/alpine3.15/zts/Dockerfile
+++ b/8.2-rc/alpine3.15/zts/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2-rc/alpine3.16/zts/Dockerfile
+++ b/8.2-rc/alpine3.16/zts/Dockerfile
@@ -163,6 +163,8 @@ RUN set -eux; \
 		--disable-cgi \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2-rc/bullseye/zts/Dockerfile
+++ b/8.2-rc/bullseye/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2-rc/buster/zts/Dockerfile
+++ b/8.2-rc/buster/zts/Dockerfile
@@ -177,6 +177,8 @@ RUN set -eux; \
 		--enable-embed \
 		\
 		--enable-zts \
+# https://externals.io/message/118859
+		--disable-zend-signals \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -393,6 +393,8 @@ RUN set -eux; \
 {{ ) else ( -}}
 		--enable-maintainer-zts \
 {{ ) end -}}
+# https://github.com/php/php-src/issues/9649#issuecomment-1264330874
+		--disable-zend-signals \
 {{ ) else "" end -}}
 	; \
 	make -j "$(nproc)"; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -393,7 +393,7 @@ RUN set -eux; \
 {{ ) else ( -}}
 		--enable-maintainer-zts \
 {{ ) end -}}
-# https://github.com/php/php-src/issues/9649#issuecomment-1264330874
+# https://externals.io/message/118859
 		--disable-zend-signals \
 {{ ) else "" end -}}
 	; \


### PR DESCRIPTION
Zend Signals are useless and cause segmentation faults when using ZTS:
* https://github.com/php/php-src/issues/9649#issuecomment-1264330874
* https://github.com/php/php-src/pull/5591#issuecomment-650064098

This patch disables Zend Signals for ZTS builds.
