### PR TITLE
Add PECL wrapper commands

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -449,7 +449,7 @@ RUN set -eux; \
 # smoke test
 	php --version
 
-COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
+COPY docker-php-ext-* docker-php-pecl-* docker-php-entrypoint /usr/local/bin/
 
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -71,6 +71,7 @@ for version; do
 		cp -a \
 			docker-php-entrypoint \
 			docker-php-ext-* \
+			docker-php-pecl-* \
 			docker-php-source \
 			"$version/$dir/"
 		if [ "$variant" = 'apache' ]; then

--- a/docker-php-pecl-configure
+++ b/docker-php-pecl-configure
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -e
+
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
+usage() {
+	echo "usage: $0 ext-name [configure flags]"
+	echo "   ie: $0 apcu --enable-apcu-spinlocks"
+	echo "       $0 -j5 apcu redis grpc protobuf"
+	echo
+	echo 'if custom ./configure arguments are necessary, see docker-php-pecl-configure'
+}
+
+if [ ! -d $tmpDir ]; then
+    if [ -e $tmpdir ]; then
+        rm -rf $tmpDir
+    fi
+    mkdir -p $tmpDir
+fi
+
+ext="$1"
+if [ -z "$ext" ]; then
+    usage >&2
+    exit 1
+fi
+shift
+
+pm='unknown'
+if [ -e /lib/apk/db/installed ]; then
+    pm='apk'
+fi
+
+if [ "$pm" = 'apk' ]; then
+	if \
+		[ -n "$PHPIZE_DEPS" ] \
+		&& ! apk info --installed .phpize-deps > /dev/null \
+		&& ! apk info --installed .phpize-deps-configure > /dev/null \
+	; then
+		apk add --no-cache --virtual .phpize-deps-configure $PHPIZE_DEPS
+	fi
+fi
+
+if command -v dpkg-architecture > /dev/null; then
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"
+	set -- --build="$gnuArch" "$@"
+fi
+
+if [ ! -z "$http_proxy" ]; then
+    pear config-set http_proxy $http_proxy
+fi
+
+pecl install --onlyreqdeps --nobuild "$ext"
+cd "/tmp/pear/temp/$ext"
+phpize
+./configure --enable-option-checking=fatal "$@"

--- a/docker-php-pecl-configure
+++ b/docker-php-pecl-configure
@@ -11,8 +11,6 @@ usage() {
 	echo "usage: $0 ext-name [configure flags]"
 	echo "   ie: $0 apcu --enable-apcu-spinlocks"
 	echo "       $0 -j5 apcu redis grpc protobuf"
-	echo
-	echo 'if custom ./configure arguments are necessary, see docker-php-pecl-configure'
 }
 
 if [ ! -d $tmpDir ]; then

--- a/docker-php-pecl-configure
+++ b/docker-php-pecl-configure
@@ -9,27 +9,27 @@ export CFLAGS CPPFLAGS LDFLAGS
 
 usage() {
 	echo "usage: $0 ext-name [configure flags]"
-	echo "   ie: $0 apcu --enable-apcu-spinlocks"
-	echo "       $0 -j5 apcu redis grpc protobuf"
+	echo "    ie: $0 apcu --enable-apcu-spinlocks"
+	echo "        $0 -j5 apcu redis grpc protobuf"
 }
 
 if [ ! -d $tmpDir ]; then
-    if [ -e $tmpdir ]; then
-        rm -rf $tmpDir
-    fi
-    mkdir -p $tmpDir
+	if [ -e $tmpdir ]; then
+		rm -rf $tmpDir
+	fi
+	mkdir -p $tmpDir
 fi
 
 ext="$1"
 if [ -z "$ext" ]; then
-    usage >&2
-    exit 1
+	usage >&2
+	exit 1
 fi
 shift
 
 pm='unknown'
 if [ -e /lib/apk/db/installed ]; then
-    pm='apk'
+	pm='apk'
 fi
 
 if [ "$pm" = 'apk' ]; then
@@ -48,7 +48,7 @@ if command -v dpkg-architecture > /dev/null; then
 fi
 
 if [ ! -z "$http_proxy" ]; then
-    pear config-set http_proxy $http_proxy
+	pear config-set http_proxy $http_proxy
 fi
 
 pecl install --onlyreqdeps --nobuild "$ext"

--- a/docker-php-pecl-install
+++ b/docker-php-pecl-install
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -e
+
+# prefer user supplied CFLAGS, but default to our PHP_CFLAGS
+: ${CFLAGS:=$PHP_CFLAGS}
+: ${CPPFLAGS:=$PHP_CPPFLAGS}
+: ${LDFLAGS:=$PHP_LDFLAGS}
+export CFLAGS CPPFLAGS LDFLAGS
+
+usage() {
+	echo "usage: $0 [-jN] [--ini-name file.ini] ext-name [ext-name ...]"
+	echo "   ie: $0 apcu redis"
+	echo "       $0 -j5 apcu redis grpc protobuf"
+	echo
+	echo 'if custom ./configure arguments are necessary, see docker-php-pecl-configure'
+}
+
+opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
+eval set -- "$opts"
+
+j=1
+iniName=
+while true; do
+	flag="$1"
+	shift
+	case "$flag" in
+		--help|-h|'-?') usage && exit 0 ;;
+		--ini-name) iniName="$1" && shift ;;
+		--jobs|-j) j="$1" && shift ;;
+		--) break ;;
+		*)
+			{
+				echo "error: unknown flag: $flag"
+				usage
+			} >&2
+			exit 1
+			;;
+	esac
+done
+
+exts=
+for ext; do
+    if [ -z "$ext" ]; then
+        continue
+    fi
+    exts="$exts $ext"
+done
+
+if [ -z "$exts" ]; then
+    usage >&2
+    exit 1
+fi
+
+popDir="$PWD"
+for ext in $exts; do
+    docker-php-pecl-configure "$ext"
+    cd "/tmp/pear/temp/$ext"
+
+    make -j"$j"
+
+	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
+		# only "strip" modules if we aren't using a debug build of PHP
+		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
+		# https://github.com/docker-library/php/issues/1268
+
+		find modules \
+			-maxdepth 1 \
+			-name '*.so' \
+			-exec sh -euxc ' \
+				strip --strip-all "$@" || :
+			' -- '{}' +
+	fi
+
+    make -j"$j" install
+
+	find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-exec basename '{}' ';' \
+			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+
+	make -j"$j" clean
+
+    cd "$popDir"
+done
+
+if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then
+	apk del --no-network $apkDel
+fi

--- a/docker-php-pecl-install
+++ b/docker-php-pecl-install
@@ -40,23 +40,23 @@ done
 
 exts=
 for ext; do
-    if [ -z "$ext" ]; then
-        continue
-    fi
-    exts="$exts $ext"
+	if [ -z "$ext" ]; then
+		continue
+	fi
+	exts="$exts $ext"
 done
 
 if [ -z "$exts" ]; then
-    usage >&2
-    exit 1
+	usage >&2
+	exit 1
 fi
 
 popDir="$PWD"
 for ext in $exts; do
-    docker-php-pecl-configure "$ext"
-    cd "/tmp/pear/temp/$ext"
+	docker-php-pecl-configure "$ext"
+	cd "/tmp/pear/temp/$ext"
 
-    make -j"$j"
+	make -j"$j"
 
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
@@ -71,7 +71,7 @@ for ext in $exts; do
 			' -- '{}' +
 	fi
 
-    make -j"$j" install
+	make -j"$j" install
 
 	find modules \
 		-maxdepth 1 \
@@ -81,7 +81,7 @@ for ext in $exts; do
 
 	make -j"$j" clean
 
-    cd "$popDir"
+	cd "$popDir"
 done
 
 if [ "$pm" = 'apk' ] && [ -n "$apkDel" ]; then


### PR DESCRIPTION
PECL use is currently supported, but PECL by default does not support parallel compilation like the -j option, and huge extensions such as gRPC take a huge amount of build time.

To solve this problem, we add a script that wraps PECL.

This is useful because so far PECL is the only native extension package manager for PHP and has many useful and essential extensions for production environments (gRPC, protobuf, APCu, Redis, etc.).