### PR TITLE
feat: generate libphp for the Alpine variant of ZTS builds

### DIFF
--- a/7.4/alpine3.15/zts/Dockerfile
+++ b/7.4/alpine3.15/zts/Dockerfile
@@ -164,6 +164,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-maintainer-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/7.4/alpine3.16/zts/Dockerfile
+++ b/7.4/alpine3.16/zts/Dockerfile
@@ -164,6 +164,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-maintainer-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.0-rc/alpine3.15/zts/Dockerfile
+++ b/8.0-rc/alpine3.15/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.0-rc/alpine3.16/zts/Dockerfile
+++ b/8.0-rc/alpine3.16/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.0/alpine3.15/zts/Dockerfile
+++ b/8.0/alpine3.15/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.0/alpine3.16/zts/Dockerfile
+++ b/8.0/alpine3.16/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.1/alpine3.15/zts/Dockerfile
+++ b/8.1/alpine3.15/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.1/alpine3.16/zts/Dockerfile
+++ b/8.1/alpine3.16/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.2-rc/alpine3.15/zts/Dockerfile
+++ b/8.2-rc/alpine3.15/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/8.2-rc/alpine3.16/zts/Dockerfile
+++ b/8.2-rc/alpine3.16/zts/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -373,7 +373,7 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 {{ ) end -}}
-{{ if (env.variant == "cli" or env.variant == "zts") and (is_alpine | not) then ( -}}
+{{ if (env.variant == "zts") or (env.variant == "cli" and (is_alpine | not)) then ( -}}
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \


### PR DESCRIPTION
The most popular use case of ZTS builds is to embed PHP in multithreaded programs such as [FrankenPHP](https://frankenphp.dev) or [NGINX Unit](https://unit.nginx.org/).

Unfortunately, generating libphp (which is necessary for this use case), is explicitly disabled for Alpine variants of the ZTS build.

This PR includes libphp in all ZTS builds (but not for the Alpine CLI variants, to keep the Alpine CLI image as small as possible).

Follows and fix https://github.com/docker-library/php/pull/1331#discussion_r1009984172.