### PR TITLE
Add an fpm-zts build

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -381,12 +381,13 @@ RUN set -eux; \
 {{ if env.variant == "apache" then ( -}}
 		\
 		--with-apxs2 \
-{{ ) elif env.variant == "fpm" then ( -}}
+{{ ) elif (env.variant == "fpm" or env.variant == "fpm-zts") then ( -}}
 		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \
-{{ ) elif env.variant == "zts" then ( -}}
+{{ ) else "" end -}}
+{{ if (env.variant == "zts" or env.variant == "fpm-zts") then ( -}}
 		\
 {{ if (.version | version_id) >= ("8" | version_id) then ( -}}
 		--enable-zts \
@@ -474,7 +475,7 @@ COPY apache2-foreground /usr/local/bin/
 WORKDIR /var/www/html
 
 EXPOSE 80
-{{ ) elif env.variant == "fpm" then ( -}}
+{{ ) elif (env.variant == "fpm" or env.variant == "fpm-zts") then ( -}}
 WORKDIR /var/www/html
 
 RUN set -eux; \

--- a/apply-templates.sh
+++ b/apply-templates.sh
@@ -56,6 +56,7 @@ for version; do
 		case "$variant" in
 			apache) cmd='["apache2-foreground"]' ;;
 			fpm) cmd='["php-fpm"]' ;;
+			fpm-zts) cmd='["php-fpm"]' ;;
 			*) cmd='["php", "-a"]' ;;
 		esac
 		export cmd

--- a/versions.sh
+++ b/versions.sh
@@ -90,7 +90,7 @@ for version in "${versions[@]}"; do
 		alpine3.16 \
 		alpine3.15 \
 	; do
-		for variant in cli apache fpm zts; do
+		for variant in cli apache fpm fpm-zts zts; do
 			if [[ "$suite" = alpine* ]]; then
 				if [ "$variant" = 'apache' ]; then
 					continue


### PR DESCRIPTION
Resolves #1317, #249

To echo [this statement](https://github.com/docker-library/php/issues/249#issuecomment-507621547) from @okdewit, I have a Symfony application using the PHP Parallel API that I cannot run correctly under FPM without ZTS.

It's not clear if there's a formal testing procedure here, but I can validate that I'm able to install the parallel extension in the php 7.4 container I've built:
```
╰─❯ docker run -it --rm php:7.4-fpm-zts bash
root@5c46acc8317c:/var/www/html# pecl install parallel-1.1.4
downloading parallel-1.1.4.tgz ...
Starting to download parallel-1.1.4.tgz (58,783 bytes)
..............done: 58,783 bytes
42 source files, building
<snip>
Build process completed successfully
Installing '/usr/local/lib/php/extensions/no-debug-zts-20190902/parallel.so'
install ok: channel://pecl.php.net/parallel-1.1.4
configuration option "php_ini" is not set to php.ini location
You should add "extension=parallel.so" to php.ini
```