### PR TITLE
Enable embed also on alpine cli

### DIFF
--- a/8.0-rc/alpine3.16/cli/Dockerfile
+++ b/8.0-rc/alpine3.16/cli/Dockerfile
@@ -160,6 +160,9 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.0/alpine3.16/cli/Dockerfile
+++ b/8.0/alpine3.16/cli/Dockerfile
@@ -160,6 +160,9 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.16/cli/Dockerfile
+++ b/8.1/alpine3.16/cli/Dockerfile
@@ -160,6 +160,9 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.17/cli/Dockerfile
+++ b/8.1/alpine3.17/cli/Dockerfile
@@ -160,6 +160,9 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2/alpine3.16/cli/Dockerfile
+++ b/8.2/alpine3.16/cli/Dockerfile
@@ -160,6 +160,9 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2/alpine3.17/cli/Dockerfile
+++ b/8.2/alpine3.17/cli/Dockerfile
@@ -160,6 +160,9 @@ RUN set -eux; \
 # bundled pcre does not support JIT on s390x
 # https://manpages.debian.org/bullseye/libpcre3-dev/pcrejit.3.en.html#AVAILABILITY_OF_JIT_SUPPORT
 		$(test "$gnuArch" = 's390x-linux-musl' && echo '--without-pcre-jit') \
+		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -357,7 +357,7 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 {{ ) end -}}
-{{ if (env.variant == "zts") or (env.variant == "cli" and (is_alpine | not)) then ( -}}
+{{ if (env.variant == "zts") or (env.variant == "cli") then ( -}}
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \


### PR DESCRIPTION
https://github.com/docker-library/php/pull/1104 added the flag to Debian-based CLI variants; in https://github.com/docker-library/php/pull/1175 was this added for debian based ZTS variants. we use an alpine-based non-zts variant, and would benefit from this flag as well.

Also, NGiNX Unit, the use case scenario mentioned in https://github.com/docker-library/php/pull/1104 [seems to work with ubuntu, but lacks alpine support because of missing embed in cli docker image).

Refs https://github.com/docker-library/php/issues/510 https://github.com/docker-library/php/pull/939 https://github.com/docker-library/php/pull/1175

After the merge it looks like this for 8.1/alpine3.17/cli:

```
$ php -i | grep Configure
Configure Command =>  './configure'  '--build=aarch64-linux-musl' '--with-config-file-path=/usr/local/etc/php' '--with-config-file-scan-dir=/usr/local/etc/php/conf.d' '--enable-option-checking=fatal' '--with-mhash' '--with-pic' '--enable-ftp' '--enable-mbstring' '--enable-mysqlnd' '--with-password-argon2' '--with-sodium=shared' '--with-pdo-sqlite=/usr' '--with-sqlite3=/usr' '--with-curl' '--with-iconv=/usr' '--with-openssl' '--with-readline' '--with-zlib' '--enable-phpdbg' '--enable-phpdbg-readline' '--with-pear' '--enable-embed' 'build_alias=aarch64-linux-musl'
```