### PR TITLE
Enable embed also on fpm on non zts

### DIFF
--- a/8.0-rc/alpine3.16/fpm/Dockerfile
+++ b/8.0-rc/alpine3.16/fpm/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.0-rc/bullseye/fpm/Dockerfile
+++ b/8.0-rc/bullseye/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.0-rc/buster/fpm/Dockerfile
+++ b/8.0-rc/buster/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.0/alpine3.16/fpm/Dockerfile
+++ b/8.0/alpine3.16/fpm/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.0/bullseye/fpm/Dockerfile
+++ b/8.0/bullseye/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.0/buster/fpm/Dockerfile
+++ b/8.0/buster/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.1/alpine3.16/fpm/Dockerfile
+++ b/8.1/alpine3.16/fpm/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.1/alpine3.17/fpm/Dockerfile
+++ b/8.1/alpine3.17/fpm/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.1/buster/fpm/Dockerfile
+++ b/8.1/buster/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.2/alpine3.16/fpm/Dockerfile
+++ b/8.2/alpine3.16/fpm/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.2/alpine3.17/fpm/Dockerfile
+++ b/8.2/alpine3.17/fpm/Dockerfile
@@ -162,6 +162,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.2/bullseye/fpm/Dockerfile
+++ b/8.2/bullseye/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/8.2/buster/fpm/Dockerfile
+++ b/8.2/buster/fpm/Dockerfile
@@ -173,6 +173,9 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 		\
+# https://github.com/docker-library/php/pull/939#issuecomment-730501748
+		--enable-embed \
+		\
 		--enable-fpm \
 		--with-fpm-user=www-data \
 		--with-fpm-group=www-data \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -357,7 +357,7 @@ RUN set -eux; \
 		\
 		--disable-cgi \
 {{ ) end -}}
-{{ if (env.variant == "zts") or (env.variant == "cli" and (is_alpine | not)) then ( -}}
+{{ if (env.variant == "zts") or (env.variant == "fpm") or (env.variant == "cli" and (is_alpine | not)) then ( -}}
 		\
 # https://github.com/docker-library/php/pull/939#issuecomment-730501748
 		--enable-embed \


### PR DESCRIPTION
> EDIT 2023/06/25: for those searching for something like this: we rolled our own based on the official alpine packages for php at https://github.com/Endava/docker-php/tree/release/8.2-zts (it supports php 8.2 with zts and following).

https://github.com/docker-library/php/pull/1104 added the flag to Debian-based CLI variants; in https://github.com/docker-library/php/pull/1175 was this added for debian based ZTS variants. we use an alpine-based non-zts variant, and would benefit from this flag as well.

Also, NGiNX Unit, the use case scenario mentioned in https://github.com/docker-library/php/pull/1104 - seems to work with ubuntu, but lacks alpine support because of missing embed in cli docker image. In https://github.com/docker-library/php/pull/1355#issuecomment-1352087633 it was requested to not add this flag to keep alpine cli image small, thus the idea is here to do it with the fpm image instead.

Refs https://github.com/docker-library/php/issues/510 https://github.com/docker-library/php/pull/939 https://github.com/docker-library/php/pull/1175 https://github.com/docker-library/php/pull/1355