### PR TITLE
Add template support for "--enable-debug" flag

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -376,10 +376,17 @@ RUN set -eux; \
 # https://externals.io/message/118859
 		--disable-zend-signals \
 {{ ) else "" end -}}
+{{ if env.DOCKER_PHP_ENABLE_DEBUG then ( -}}
+{{ # DOCKER_PHP_ENABLE_DEBUG is not used or supported by official-images; this is for users who want to build their own php image with debug enabled -}}
+{{ # example usage to regenerate Dockerfiles with debug enabled: "DOCKER_PHP_ENABLE_DEBUG=1 ./apply-templates" -}}
+		--enable-debug \
+{{ ) else "" end -}}
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \
 	make install; \
+{{ if env.DOCKER_PHP_ENABLE_DEBUG then "" else ( -}}
+{{ # DOCKER_PHP_ENABLE_DEBUG is not used by official-images -}}
 	find \
 		/usr/local \
 		-type f \
@@ -388,6 +395,7 @@ RUN set -eux; \
 			strip --strip-all "$@" || : \
 		' -- '{}' + \
 	; \
+{{ ) end -}}
 	make clean; \
 	\
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)


### PR DESCRIPTION
> DOCKER_PHP_ENABLE_DEBUG is not used or supported by official-images; this is for users who want to build their own php image with debug enabled

This will allow power users to generate their own PHP Dockerfiles with debug enabled. This is explicitly written to not change the regular versions of the Dockerfiles (i.e. running `./apply-templates.sh` will result in no change). I have build tested one or two versions and they seem to work:

```console
$ docker build 8.0/alpine3.16/cli/
...
Successfully built 7feb88eade75
$ docker run -it --rm 7feb88eade75 php -i
...
Debug Build => yes
...
```

To regenerate all the Dockerfiles with debug enabled (`bash`, `jq`, `gawk`, and `wget` are required to run it):
```console
$ DOCKER_PHP_ENABLE_DEBUG=1 ./apply-templates
processing 8.0/bullseye/cli ...
processing 8.0/bullseye/apache ...
[...]
processing 8.2-rc/alpine3.16/fpm ...
processing 8.2-rc/alpine3.16/zts ...
```

Alternative to https://github.com/docker-library/php/pull/1287 and https://github.com/docker-library/php/pull/1280.

Closes https://github.com/docker-library/php/pull/1287
Closes https://github.com/docker-library/php/pull/1280