### PR TITLE
enable Max Execution Timers for ZTS builds

### DIFF
--- a/8.1/alpine3.16/zts/Dockerfile
+++ b/8.1/alpine3.16/zts/Dockerfile
@@ -168,6 +168,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.17/zts/Dockerfile
+++ b/8.1/alpine3.17/zts/Dockerfile
@@ -168,6 +168,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/alpine3.18/zts/Dockerfile
+++ b/8.1/alpine3.18/zts/Dockerfile
@@ -168,6 +168,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -179,6 +179,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.1/buster/zts/Dockerfile
+++ b/8.1/buster/zts/Dockerfile
@@ -179,6 +179,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2/alpine3.17/zts/Dockerfile
+++ b/8.2/alpine3.17/zts/Dockerfile
@@ -168,6 +168,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2/alpine3.18/zts/Dockerfile
+++ b/8.2/alpine3.18/zts/Dockerfile
@@ -168,6 +168,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2/bullseye/zts/Dockerfile
+++ b/8.2/bullseye/zts/Dockerfile
@@ -179,6 +179,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/8.2/buster/zts/Dockerfile
+++ b/8.2/buster/zts/Dockerfile
@@ -179,6 +179,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+		--enable-zend-max-execution-timers \
 	; \
 	make -j "$(nproc)"; \
 	find -type f -name '*.a' -delete; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -383,7 +383,7 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
-{{ if ((.version | version_id) >= ("8.2.4" | version_id) and (.version | version_id) < ("8.3" | version_id)) or ((.version | version_id) >= ("8.1.17" | version_id) and (.version | version_id) < ("8.2" | version_id)) then ( -}}
+{{ if [ "8.1", "8.2" ] | index(env.version | rtrimstr("-rc")) then ( -}}
 		--enable-zend-max-execution-timers \
 {{ ) else "" end -}}
 {{ ) else "" end -}}

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -383,6 +383,9 @@ RUN set -eux; \
 		--enable-zts \
 # https://externals.io/message/118859
 		--disable-zend-signals \
+{{ if ((.version | version_id) >= ("8.2.4" | version_id) and (.version | version_id) < ("8.3" | version_id)) or ((.version | version_id) >= ("8.1.17" | version_id) and (.version | version_id) < ("8.2" | version_id)) then ( -}}
+		--enable-zend-max-execution-timers \
+{{ ) else "" end -}}
 {{ ) else "" end -}}
 	; \
 	make -j "$(nproc)"; \


### PR DESCRIPTION
https://github.com/php/php-src/pull/10141 has just been merged. It fixes timeout support for ZTS builds on Linux.
This feature will be enabled by default in PHP 8.3. It hasn't been in previous version because it introduces an ABI break, but it's not a big issue when using the Docker images because the extensions are usually compiled against the local version of PHP. This patch enables this fix.