### PR TITLE
Optimize Debian fpm size

### DIFF
--- a/8.2/bullseye/fpm/Dockerfile
+++ b/8.2/bullseye/fpm/Dockerfile
@@ -32,6 +32,7 @@ ENV PHPIZE_DEPS \
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -101,7 +102,6 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		$PHPIZE_DEPS \
 		libargon2-dev \
 		libcurl4-openssl-dev \
 		libonig-dev \

--- a/8.2/bullseye/fpm/Dockerfile
+++ b/8.2/bullseye/fpm/Dockerfile
@@ -32,7 +32,6 @@ ENV PHPIZE_DEPS \
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -102,6 +101,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		$PHPIZE_DEPS \
 		libargon2-dev \
 		libcurl4-openssl-dev \
 		libonig-dev \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -64,7 +64,6 @@ RUN set -eux; \
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		$PHPIZE_DEPS \
 		ca-certificates \
 		curl \
 		xz-utils \
@@ -259,6 +258,7 @@ RUN set -eux; \
 		else
 			# debian packages
 			if env.variant == "apache" then "apache2-dev" else empty end,
+			"$PHPIZE_DEPS",
 			"libargon2-dev",
 			"libcurl4-openssl-dev",
 			"libreadline-dev",


### PR DESCRIPTION
Debian fpm docker size is huge compare to alpine,
This request removes PHPIZE_DEPS from docker.
Docker size reduces to almost on half.