### PR TITLE
hf: curl version pin to 8.4 to fix CVE-2023-38545 and CVE-2023-38546 #1449

### DIFF
--- a/8.0/alpine3.16/cli/Dockerfile
+++ b/8.0/alpine3.16/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.0/alpine3.16/fpm/Dockerfile
+++ b/8.0/alpine3.16/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.0/alpine3.16/zts/Dockerfile
+++ b/8.0/alpine3.16/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.16/cli/Dockerfile
+++ b/8.1/alpine3.16/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.16/fpm/Dockerfile
+++ b/8.1/alpine3.16/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.16/zts/Dockerfile
+++ b/8.1/alpine3.16/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.17/cli/Dockerfile
+++ b/8.1/alpine3.17/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.17/fpm/Dockerfile
+++ b/8.1/alpine3.17/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.17/zts/Dockerfile
+++ b/8.1/alpine3.17/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.18/cli/Dockerfile
+++ b/8.1/alpine3.18/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.18/fpm/Dockerfile
+++ b/8.1/alpine3.18/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.1/alpine3.18/zts/Dockerfile
+++ b/8.1/alpine3.18/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.2/alpine3.17/cli/Dockerfile
+++ b/8.2/alpine3.17/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.2/alpine3.17/fpm/Dockerfile
+++ b/8.2/alpine3.17/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.2/alpine3.17/zts/Dockerfile
+++ b/8.2/alpine3.17/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.2/alpine3.18/cli/Dockerfile
+++ b/8.2/alpine3.18/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.2/alpine3.18/fpm/Dockerfile
+++ b/8.2/alpine3.18/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.2/alpine3.18/zts/Dockerfile
+++ b/8.2/alpine3.18/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.3-rc/alpine3.17/cli/Dockerfile
+++ b/8.3-rc/alpine3.17/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.3-rc/alpine3.17/fpm/Dockerfile
+++ b/8.3-rc/alpine3.17/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.3-rc/alpine3.17/zts/Dockerfile
+++ b/8.3-rc/alpine3.17/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.3-rc/alpine3.18/cli/Dockerfile
+++ b/8.3-rc/alpine3.18/cli/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.3-rc/alpine3.18/fpm/Dockerfile
+++ b/8.3-rc/alpine3.18/fpm/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/8.3-rc/alpine3.18/zts/Dockerfile
+++ b/8.3-rc/alpine3.18/zts/Dockerfile
@@ -22,7 +22,7 @@ ENV PHPIZE_DEPS \
 # persistent / runtime deps
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -47,7 +47,7 @@ ENV PHPIZE_DEPS \
 {{ if is_alpine then ( -}}
 RUN apk add --no-cache \
 		ca-certificates \
-		curl \
+		'curl>=8.4' \
 		tar \
 		xz \
 # https://github.com/docker-library/php/issues/494


### PR DESCRIPTION
version pin curl to fix #1449

I didn't see that the alpine images where pushed already. This will force everything to upgrade to atleast version 8.4

based upon this schema, all alpine version allow for 8.4 to be added from the alpine repository:
https://security.alpinelinux.org/srcpkg/curl