### PR TITLE
Fix permissions on $APACHE_RUN_DIR/socks in Debian Bookworm+

### DIFF
--- a/8.1-rc/bookworm/apache/Dockerfile
+++ b/8.1-rc/bookworm/apache/Dockerfile
@@ -70,6 +70,8 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \

--- a/8.1/bookworm/apache/Dockerfile
+++ b/8.1/bookworm/apache/Dockerfile
@@ -70,6 +70,8 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \

--- a/8.2-rc/bookworm/apache/Dockerfile
+++ b/8.2-rc/bookworm/apache/Dockerfile
@@ -70,6 +70,8 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \

--- a/8.2/bookworm/apache/Dockerfile
+++ b/8.2/bookworm/apache/Dockerfile
@@ -70,6 +70,8 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \

--- a/8.3-rc/bookworm/apache/Dockerfile
+++ b/8.3-rc/bookworm/apache/Dockerfile
@@ -70,6 +70,8 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \

--- a/8.3/bookworm/apache/Dockerfile
+++ b/8.3/bookworm/apache/Dockerfile
@@ -70,6 +70,8 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -103,6 +103,10 @@ RUN set -eux; \
 		"$APACHE_LOCK_DIR" \
 		"$APACHE_RUN_DIR" \
 		"$APACHE_LOG_DIR" \
+{{ if [ "bullseye" ] | index(env.suite) then "" else ( -}}
+# https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205
+		"$APACHE_RUN_DIR/socks" \
+{{ ) end -}}
 	; do \
 		rm -rvf "$dir"; \
 		mkdir -p "$dir"; \


### PR DESCRIPTION
See https://salsa.debian.org/apache-team/apache2/-/commit/b97ca8714890ead1ba6c095699dde752e8433205

Fixes #1444