### PR TITLE
Set PHP_UNAME to a fixed value too

### DIFF
--- a/8.1-rc/alpine3.18/cli/Dockerfile
+++ b/8.1-rc/alpine3.18/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/alpine3.18/fpm/Dockerfile
+++ b/8.1-rc/alpine3.18/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/alpine3.18/zts/Dockerfile
+++ b/8.1-rc/alpine3.18/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/alpine3.19/cli/Dockerfile
+++ b/8.1-rc/alpine3.19/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/alpine3.19/fpm/Dockerfile
+++ b/8.1-rc/alpine3.19/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/alpine3.19/zts/Dockerfile
+++ b/8.1-rc/alpine3.19/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bookworm/apache/Dockerfile
+++ b/8.1-rc/bookworm/apache/Dockerfile
@@ -178,8 +178,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bookworm/cli/Dockerfile
+++ b/8.1-rc/bookworm/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bookworm/fpm/Dockerfile
+++ b/8.1-rc/bookworm/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bookworm/zts/Dockerfile
+++ b/8.1-rc/bookworm/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bullseye/apache/Dockerfile
+++ b/8.1-rc/bullseye/apache/Dockerfile
@@ -176,8 +176,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bullseye/cli/Dockerfile
+++ b/8.1-rc/bullseye/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bullseye/fpm/Dockerfile
+++ b/8.1-rc/bullseye/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1-rc/bullseye/zts/Dockerfile
+++ b/8.1-rc/bullseye/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/alpine3.18/cli/Dockerfile
+++ b/8.1/alpine3.18/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/alpine3.18/fpm/Dockerfile
+++ b/8.1/alpine3.18/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/alpine3.18/zts/Dockerfile
+++ b/8.1/alpine3.18/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/alpine3.19/cli/Dockerfile
+++ b/8.1/alpine3.19/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/alpine3.19/fpm/Dockerfile
+++ b/8.1/alpine3.19/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/alpine3.19/zts/Dockerfile
+++ b/8.1/alpine3.19/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bookworm/apache/Dockerfile
+++ b/8.1/bookworm/apache/Dockerfile
@@ -178,8 +178,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bookworm/cli/Dockerfile
+++ b/8.1/bookworm/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bookworm/fpm/Dockerfile
+++ b/8.1/bookworm/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bookworm/zts/Dockerfile
+++ b/8.1/bookworm/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bullseye/apache/Dockerfile
+++ b/8.1/bullseye/apache/Dockerfile
@@ -176,8 +176,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bullseye/cli/Dockerfile
+++ b/8.1/bullseye/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/alpine3.18/cli/Dockerfile
+++ b/8.2-rc/alpine3.18/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/alpine3.18/fpm/Dockerfile
+++ b/8.2-rc/alpine3.18/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/alpine3.18/zts/Dockerfile
+++ b/8.2-rc/alpine3.18/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/alpine3.19/cli/Dockerfile
+++ b/8.2-rc/alpine3.19/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/alpine3.19/fpm/Dockerfile
+++ b/8.2-rc/alpine3.19/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/alpine3.19/zts/Dockerfile
+++ b/8.2-rc/alpine3.19/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bookworm/apache/Dockerfile
+++ b/8.2-rc/bookworm/apache/Dockerfile
@@ -178,8 +178,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bookworm/cli/Dockerfile
+++ b/8.2-rc/bookworm/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bookworm/fpm/Dockerfile
+++ b/8.2-rc/bookworm/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bookworm/zts/Dockerfile
+++ b/8.2-rc/bookworm/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bullseye/apache/Dockerfile
+++ b/8.2-rc/bullseye/apache/Dockerfile
@@ -176,8 +176,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bullseye/cli/Dockerfile
+++ b/8.2-rc/bullseye/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bullseye/fpm/Dockerfile
+++ b/8.2-rc/bullseye/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2-rc/bullseye/zts/Dockerfile
+++ b/8.2-rc/bullseye/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/alpine3.18/cli/Dockerfile
+++ b/8.2/alpine3.18/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/alpine3.18/fpm/Dockerfile
+++ b/8.2/alpine3.18/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/alpine3.18/zts/Dockerfile
+++ b/8.2/alpine3.18/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/alpine3.19/cli/Dockerfile
+++ b/8.2/alpine3.19/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/alpine3.19/fpm/Dockerfile
+++ b/8.2/alpine3.19/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/alpine3.19/zts/Dockerfile
+++ b/8.2/alpine3.19/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bookworm/apache/Dockerfile
+++ b/8.2/bookworm/apache/Dockerfile
@@ -178,8 +178,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bookworm/cli/Dockerfile
+++ b/8.2/bookworm/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bookworm/fpm/Dockerfile
+++ b/8.2/bookworm/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bookworm/zts/Dockerfile
+++ b/8.2/bookworm/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bullseye/apache/Dockerfile
+++ b/8.2/bullseye/apache/Dockerfile
@@ -176,8 +176,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bullseye/cli/Dockerfile
+++ b/8.2/bullseye/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bullseye/fpm/Dockerfile
+++ b/8.2/bullseye/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.2/bullseye/zts/Dockerfile
+++ b/8.2/bullseye/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/alpine3.18/cli/Dockerfile
+++ b/8.3-rc/alpine3.18/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/alpine3.18/fpm/Dockerfile
+++ b/8.3-rc/alpine3.18/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/alpine3.18/zts/Dockerfile
+++ b/8.3-rc/alpine3.18/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/alpine3.19/cli/Dockerfile
+++ b/8.3-rc/alpine3.19/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/alpine3.19/fpm/Dockerfile
+++ b/8.3-rc/alpine3.19/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/alpine3.19/zts/Dockerfile
+++ b/8.3-rc/alpine3.19/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bookworm/apache/Dockerfile
+++ b/8.3-rc/bookworm/apache/Dockerfile
@@ -178,8 +178,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bookworm/cli/Dockerfile
+++ b/8.3-rc/bookworm/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bookworm/fpm/Dockerfile
+++ b/8.3-rc/bookworm/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bookworm/zts/Dockerfile
+++ b/8.3-rc/bookworm/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bullseye/apache/Dockerfile
+++ b/8.3-rc/bullseye/apache/Dockerfile
@@ -176,8 +176,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bullseye/cli/Dockerfile
+++ b/8.3-rc/bullseye/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bullseye/fpm/Dockerfile
+++ b/8.3-rc/bullseye/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3-rc/bullseye/zts/Dockerfile
+++ b/8.3-rc/bullseye/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/alpine3.18/cli/Dockerfile
+++ b/8.3/alpine3.18/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/alpine3.18/fpm/Dockerfile
+++ b/8.3/alpine3.18/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/alpine3.18/zts/Dockerfile
+++ b/8.3/alpine3.18/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/alpine3.19/cli/Dockerfile
+++ b/8.3/alpine3.19/cli/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/alpine3.19/fpm/Dockerfile
+++ b/8.3/alpine3.19/fpm/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/alpine3.19/zts/Dockerfile
+++ b/8.3/alpine3.19/zts/Dockerfile
@@ -111,8 +111,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bookworm/apache/Dockerfile
+++ b/8.3/bookworm/apache/Dockerfile
@@ -178,8 +178,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bookworm/cli/Dockerfile
+++ b/8.3/bookworm/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bookworm/fpm/Dockerfile
+++ b/8.3/bookworm/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bookworm/zts/Dockerfile
+++ b/8.3/bookworm/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bullseye/apache/Dockerfile
+++ b/8.3/bullseye/apache/Dockerfile
@@ -176,8 +176,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bullseye/cli/Dockerfile
+++ b/8.3/bullseye/cli/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bullseye/fpm/Dockerfile
+++ b/8.3/bullseye/fpm/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/8.3/bullseye/zts/Dockerfile
+++ b/8.3/bullseye/zts/Dockerfile
@@ -117,8 +117,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -290,8 +290,9 @@ RUN set -eux; \
 		CFLAGS="$PHP_CFLAGS" \
 		CPPFLAGS="$PHP_CPPFLAGS" \
 		LDFLAGS="$PHP_LDFLAGS" \
-# https://github.com/php/php-src/blob/789867e844dc0465fe01a703a1bef2a7dba0c62b/configure.ac#L1500-L1502
+# https://github.com/php/php-src/blob/d6299206dd828382753453befd1b915491b741c6/configure.ac#L1496-L1511
 		PHP_BUILD_PROVIDER='https://github.com/docker-library/php' \
+		PHP_UNAME='Linux - Docker' \
 	; \
 	docker-php-source extract; \
 	cd /usr/src/php; \


### PR DESCRIPTION
The exact kernel/host details of the build system this image compiles on aren't terribly relevant to end users.

Before:

```console
root@eba82b7c80aa:/# php -i | grep -E '^Build System'
Build System => Linux d27aa0629870 5.10.0-13-cloud-amd64 #1 SMP Debian 5.10.106-1 (2022-03-17) x86_64 GNU/Linux
```

After:

```console
root@57a767215ae4:/# php -i | grep -E '^Build System'
Build System => Linux - Docker
```