### PR TITLE
Bump PHP 8.2 and 8.3 to the latest Nov 21 2024 releases

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -67,6 +67,5 @@
     ],
     "version": "8.3.14"
   },
-  "8.3-rc": null,
-  "8.4-rc": null
+  "8.3-rc": null
 }


### PR DESCRIPTION
Includes security updates with versions 8.2.26 and 8.3.14