### PR TITLE
Change default Alpine image for 8.1

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -117,6 +117,13 @@ for version; do
 			)
 		)
 		| .[0]
+		# intl will not compile on Alpine 3.22 causing build failures for downstream images (joomla, mediawiki, wordpress): https://github.com/docker-library/php/issues/1585
+		# since PHP 8.1 is EOL at the end of the year and wont likely get fixes, keep the default Alpine at 3.21
+		| if env.version == "8.1" then
+			"alpine3.21"
+		else
+			.
+		end
 	' versions.json)"
 
 	for dir in "${variants[@]}"; do


### PR DESCRIPTION
Because of the errors seen in https://github.com/docker-library/php/issues/1585, many of the DOI images will not build successfully on Alpine 3.22. Given the near end-of-life nature of PHP 8.1, it seems unlikely that a fix will come.

All of the current failing builds (`joomla`, `mediawiki`, `wordpress`) rely on the default Alpine version (correctly or incorrectly).  For the one we directly maintain (`wordpress`), we don't have a concept of following a specific Alpine version, and I figured this would be the easier/faster fix.

These are all from `php:8.1-*alpine` and so will be fixed by staying on Alpine 3.21 (until PHP 8.1 is end of life)
- [joomla:4.4.13-php8.1-fpm-alpine](https://github.com/joomla-docker/docker-joomla/blob/2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5/4.4/php8.1/fpm-alpine/Dockerfile)
- [joomla:5.3.1-php8.1-fpm-alpine](https://github.com/joomla-docker/docker-joomla/blob/5bd86402acfa528dac7dfa6eea3d27d0fc1de5f6/5.3/php8.1/fpm-alpine/Dockerfile)
- [mediawiki:1.43.1-fpm-alpine](https://github.com/wikimedia/mediawiki-docker/blob/76236dfa180c94c95410242a17d6dc8603ba3990/1.43/fpm-alpine/Dockerfile)
- [mediawiki:1.42.6-fpm-alpine](https://github.com/wikimedia/mediawiki-docker/blob/76236dfa180c94c95410242a17d6dc8603ba3990/1.42/fpm-alpine/Dockerfile)
- [mediawiki:1.39.12-fpm-alpine](https://github.com/wikimedia/mediawiki-docker/blob/76236dfa180c94c95410242a17d6dc8603ba3990/1.39/fpm-alpine/Dockerfile)
- [wordpress:6.8.1-php8.1-fpm-alpine](https://github.com/docker-library/wordpress/blob/b8721d7271bf763d999285985277d61e78c584aa/latest/php8.1/fpm-alpine/Dockerfile)
- [wordpress:cli-2.12.0-php8.1](https://github.com/docker-library/wordpress/blob/50da133eabc137fa07c620c77788c1237cf55c8b/cli/php8.1/alpine/Dockerfile)

Fixes #1585

<details>
<summary>Error log:</summary>

```console
make: *** [Makefile:377: intl_convertcpp.lo] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:380: common/common_enum.lo] Error 1
In file included from /usr/include/unicode/locid.h:39,
                 from /usr/include/unicode/calendar.h:41,
                 from /usr/src/php/ext/intl/common/common_date.cpp:17:
/usr/include/unicode/localpointer.h:561:26: error: parameter declared 'auto'
  561 | template <typename Type, auto closeFunction>
      |                          ^~~~
/usr/include/unicode/localpointer.h:573:76: error: template argument 2 is invalid
  573 |     explicit LocalOpenPointer(std::unique_ptr<Type, decltype(closeFunction)> &&p)
      |                                                                            ^
/usr/include/unicode/localpointer.h:583:78: error: template argument 2 is invalid
  583 |     LocalOpenPointer &operator=(std::unique_ptr<Type, decltype(closeFunction)> &&p) {
      |                                                                              ^
/usr/include/unicode/localpointer.h:599:59: error: template argument 2 is invalid
  599 |     operator std::unique_ptr<Type, decltype(closeFunction)> () && {
      |                                                           ^
In file included from /usr/include/unicode/unistr.h:37,
                 from /usr/include/unicode/strenum.h:20,
                 from /usr/include/unicode/locid.h:40:
/usr/include/unicode/char16ptr.h:317:10: error: 'is_convertible_v' is not a member of 'std'; did you mean 'is_convertible'?
  317 |     std::is_convertible_v<T, std::u16string_view>
      |          ^~~~~~~~~~~~~~~~
      |          is_convertible
/usr/include/unicode/char16ptr.h:317:28: error: expected primary-expression before ',' token
  317 |     std::is_convertible_v<T, std::u16string_view>
      |                            ^
/usr/include/unicode/char16ptr.h:331:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  331 | inline std::u16string_view toU16StringView(std::u16string_view sv) { return sv; }
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:339:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  339 | inline std::u16string_view toU16StringView(std::basic_string_view<uint16_t> sv) {
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:360:36: error: 'enable_if_t' in namespace 'std' does not name a template type
  360 |           typename = typename std::enable_if_t<!std::is_pointer_v<std::remove_reference_t<T>>>>
      |                                    ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:360:36: note: 'std::enable_if_t' is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:360:47: error: expected '>' before '<' token
  360 |           typename = typename std::enable_if_t<!std::is_pointer_v<std::remove_reference_t<T>>>>
      |                                               ^
/usr/include/unicode/char16ptr.h:361:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  361 | inline std::u16string_view toU16StringViewNullable(const T& text) {
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:370:36: error: 'enable_if_t' in namespace 'std' does not name a template type
  370 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
      |                                    ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:370:36: note: 'std::enable_if_t' is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:370:47: error: expected '>' before '<' token
  370 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
      |                                               ^
/usr/include/unicode/char16ptr.h:372:13: error: 'u16string_view' in namespace 'std' does not name a type; did you mean 'u16string'?
  372 | inline std::u16string_view toU16StringViewNullable(const T& text) {
      |             ^~~~~~~~~~~~~~
      |             u16string
In file included from /usr/include/unicode/unistr.h:40:
/usr/include/unicode/stringpiece.h:134:29: error: 'enable_if_t' in namespace 'std' does not name a template type
  134 |             typename = std::enable_if_t<
      |                             ^~~~~~~~~~~
/usr/include/unicode/stringpiece.h:134:24: note: 'std::enable_if_t' is only available from C++14 onwards
  134 |             typename = std::enable_if_t<
      |                        ^~~
/usr/include/unicode/stringpiece.h:134:40: error: expected '>' before '<' token
  134 |             typename = std::enable_if_t<
      |                                        ^
/usr/include/unicode/stringpiece.h:185:19: error: expected type-specifier
  185 |   inline operator std::string_view() const {
      |                   ^~~
/usr/include/unicode/unistr.h:346:40: error: 'enable_if_t' in namespace 'std' does not name a template type
  346 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:346:35: note: 'std::enable_if_t' is only available from C++14 onwards
  346 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:346:51: error: expected '>' before '<' token
  346 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:381:40: error: 'enable_if_t' in namespace 'std' does not name a template type
  381 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:381:35: note: 'std::enable_if_t' is only available from C++14 onwards
  381 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:381:51: error: expected '>' before '<' token
  381 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:1959:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 1959 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:1959:35: note: 'std::enable_if_t' is only available from C++14 onwards
 1959 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:1959:51: error: expected '>' before '<' token
 1959 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:2226:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 2226 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2226:35: note: 'std::enable_if_t' is only available from C++14 onwards
 2226 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2226:51: error: expected '>' before '<' token
 2226 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:2299:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 2299 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2299:35: note: 'std::enable_if_t' is only available from C++14 onwards
 2299 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2299:51: error: expected '>' before '<' token
 2299 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3035:19: error: expected type-specifier
 3035 |   inline operator std::u16string_view() const {
      |                   ^~~
/usr/include/unicode/unistr.h:3273:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 3273 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:3273:35: note: 'std::enable_if_t' is only available from C++14 onwards
 3273 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:3273:51: error: expected '>' before '<' token
 3273 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3599:40: error: 'enable_if_t' in namespace 'std' does not name a template type
 3599 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:3599:35: note: 'std::enable_if_t' is only available from C++14 onwards
 3599 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:3599:51: error: expected '>' before '<' token
 3599 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3755:60: error: 'std::u16string_view' has not been declared
 3755 |   static UnicodeString readOnlyAliasFromU16StringView(std::u16string_view text);
      |                                                            ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:3871:64: error: 'std::u16string_view' has not been declared
 3871 |   UnicodeString& doReplace(int32_t start, int32_t length, std::u16string_view src);
      |                                                                ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:3875:32: error: 'std::u16string_view' has not been declared
 3875 |   UnicodeString& doAppend(std::u16string_view src);
      |                                ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function 'bool icu_76::UnicodeString::operator==(const S&) const':
/usr/include/unicode/unistr.h:348:10: error: 'u16string_view' is not a member of 'std'; did you mean 'u16string'?
  348 |     std::u16string_view sv(internal::toU16StringView(text));
      |          ^~~~~~~~~~~~~~
      |          u16string
/usr/include/unicode/unistr.h:350:46: error: 'sv' was not declared in this scope
  350 |     return !isBogus() && (len = length()) == sv.length() && doEquals(sv.data(), len);
      |                                              ^~
/usr/include/unicode/unistr.h: In member function 'icu_76::UnicodeString& icu_76::UnicodeString::operator=(const S&)':
/usr/include/unicode/unistr.h:1962:45: error: 'toU16StringView' is not a member of 'icu_76::internal'
 1962 |     return doReplace(0, length(), internal::toU16StringView(src));
      |                                             ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function 'icu_76::UnicodeString& icu_76::UnicodeString::operator+=(const S&)':
/usr/include/unicode/unistr.h:2228:31: error: 'toU16StringView' is not a member of 'icu_76::internal'
 2228 |     return doAppend(internal::toU16StringView(src));
      |                               ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function 'icu_76::UnicodeString& icu_76::UnicodeString::append(const S&)':
/usr/include/unicode/unistr.h:2301:31: error: 'toU16StringView' is not a member of 'icu_76::internal'
 2301 |     return doAppend(internal::toU16StringView(src));
      |                               ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In constructor 'icu_76::UnicodeString::UnicodeString(const S&)':
/usr/include/unicode/unistr.h:3276:24: error: 'toU16StringViewNullable' is not a member of 'icu_76::internal'
 3276 |     doAppend(internal::toU16StringViewNullable(text));
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In static member function 'static icu_76::UnicodeString icu_76::UnicodeString::readOnlyAlias(const S&)':
/usr/include/unicode/unistr.h:3601:53: error: 'toU16StringView' is not a member of 'icu_76::internal'
 3601 |     return readOnlyAliasFromU16StringView(internal::toU16StringView(text));
      |                                                     ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:4116:38: error: 'enable_if_t' in namespace 'std' does not name a template type
 4116 | template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                      ^~~~~~~~~~~
/usr/include/unicode/unistr.h:4116:33: note: 'std::enable_if_t' is only available from C++14 onwards
 4116 | template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                 ^~~
/usr/include/unicode/unistr.h:4116:49: error: expected '>' before '<' token
 4116 | template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                 ^
/usr/include/unicode/unistr.h: In function 'icu_76::UnicodeString icu_76::operator+(const UnicodeString&, const S&)':
/usr/include/unicode/unistr.h:4118:46: error: 'toU16StringView' is not a member of 'icu_76::internal'
 4118 |   return unistr_internalConcat(s1, internal::toU16StringView(s2));
      |                                              ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:4118:10: error: there are no arguments to 'unistr_internalConcat' that depend on a template parameter, so a declaration of 'unistr_internalConcat' must be available [-fpermissive]
 4118 |   return unistr_internalConcat(s1, internal::toU16StringView(s2));
      |          ^~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:4118:10: note: (if you use '-fpermissive', G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:4125:53: error: 'std::u16string_view' has not been declared
 4125 | unistr_internalConcat(const UnicodeString &s1, std::u16string_view s2);
      |                                                     ^~~~~~~~~~~~~~
/usr/include/unicode/uenum.h:69:1: note: invalid template non-type parameter
   69 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/ures.h:268:1: note: invalid template non-type parameter
  268 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUResourceBundlePointer, UResourceBundle, ures_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/ucal.h:803:1: note: invalid template non-type parameter
  803 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUCalendarPointer, UCalendar, ucal_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:383: common/common_date.lo] Error 1
```

</details>