### PR TITLE
Enable opcache by default

### DIFF
--- a/8.1/alpine3.21/cli/Dockerfile
+++ b/8.1/alpine3.21/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/alpine3.21/cli/docker-php-ext-install
+++ b/8.1/alpine3.21/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/alpine3.21/fpm/Dockerfile
+++ b/8.1/alpine3.21/fpm/Dockerfile
@@ -220,6 +220,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/alpine3.21/fpm/docker-php-ext-install
+++ b/8.1/alpine3.21/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/alpine3.21/zts/Dockerfile
+++ b/8.1/alpine3.21/zts/Dockerfile
@@ -223,6 +223,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/alpine3.21/zts/docker-php-ext-install
+++ b/8.1/alpine3.21/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/alpine3.22/cli/Dockerfile
+++ b/8.1/alpine3.22/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/alpine3.22/cli/docker-php-ext-install
+++ b/8.1/alpine3.22/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/alpine3.22/fpm/Dockerfile
+++ b/8.1/alpine3.22/fpm/Dockerfile
@@ -220,6 +220,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/alpine3.22/fpm/docker-php-ext-install
+++ b/8.1/alpine3.22/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/alpine3.22/zts/Dockerfile
+++ b/8.1/alpine3.22/zts/Dockerfile
@@ -229,6 +229,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/alpine3.22/zts/docker-php-ext-install
+++ b/8.1/alpine3.22/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bookworm/apache/Dockerfile
+++ b/8.1/bookworm/apache/Dockerfile
@@ -282,6 +282,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bookworm/apache/docker-php-ext-install
+++ b/8.1/bookworm/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bookworm/cli/Dockerfile
+++ b/8.1/bookworm/cli/Dockerfile
@@ -221,6 +221,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bookworm/cli/docker-php-ext-install
+++ b/8.1/bookworm/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bookworm/fpm/Dockerfile
+++ b/8.1/bookworm/fpm/Dockerfile
@@ -223,6 +223,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bookworm/fpm/docker-php-ext-install
+++ b/8.1/bookworm/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bookworm/zts/Dockerfile
+++ b/8.1/bookworm/zts/Dockerfile
@@ -226,6 +226,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bookworm/zts/docker-php-ext-install
+++ b/8.1/bookworm/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bullseye/apache/Dockerfile
+++ b/8.1/bullseye/apache/Dockerfile
@@ -280,6 +280,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bullseye/apache/docker-php-ext-install
+++ b/8.1/bullseye/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bullseye/cli/Dockerfile
+++ b/8.1/bullseye/cli/Dockerfile
@@ -221,6 +221,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bullseye/cli/docker-php-ext-install
+++ b/8.1/bullseye/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bullseye/fpm/Dockerfile
+++ b/8.1/bullseye/fpm/Dockerfile
@@ -223,6 +223,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bullseye/fpm/docker-php-ext-install
+++ b/8.1/bullseye/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.1/bullseye/zts/Dockerfile
+++ b/8.1/bullseye/zts/Dockerfile
@@ -226,6 +226,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.1/bullseye/zts/docker-php-ext-install
+++ b/8.1/bullseye/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/alpine3.21/cli/Dockerfile
+++ b/8.2/alpine3.21/cli/Dockerfile
@@ -200,6 +200,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/alpine3.21/cli/docker-php-ext-install
+++ b/8.2/alpine3.21/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/alpine3.21/fpm/Dockerfile
+++ b/8.2/alpine3.21/fpm/Dockerfile
@@ -205,6 +205,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/alpine3.21/fpm/docker-php-ext-install
+++ b/8.2/alpine3.21/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/alpine3.21/zts/Dockerfile
+++ b/8.2/alpine3.21/zts/Dockerfile
@@ -208,6 +208,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/alpine3.21/zts/docker-php-ext-install
+++ b/8.2/alpine3.21/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/alpine3.22/cli/Dockerfile
+++ b/8.2/alpine3.22/cli/Dockerfile
@@ -200,6 +200,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/alpine3.22/cli/docker-php-ext-install
+++ b/8.2/alpine3.22/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/alpine3.22/fpm/Dockerfile
+++ b/8.2/alpine3.22/fpm/Dockerfile
@@ -205,6 +205,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/alpine3.22/fpm/docker-php-ext-install
+++ b/8.2/alpine3.22/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/alpine3.22/zts/Dockerfile
+++ b/8.2/alpine3.22/zts/Dockerfile
@@ -216,6 +216,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/alpine3.22/zts/docker-php-ext-install
+++ b/8.2/alpine3.22/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bookworm/apache/Dockerfile
+++ b/8.2/bookworm/apache/Dockerfile
@@ -280,6 +280,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bookworm/apache/docker-php-ext-install
+++ b/8.2/bookworm/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bookworm/cli/Dockerfile
+++ b/8.2/bookworm/cli/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bookworm/cli/docker-php-ext-install
+++ b/8.2/bookworm/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bookworm/fpm/Dockerfile
+++ b/8.2/bookworm/fpm/Dockerfile
@@ -221,6 +221,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bookworm/fpm/docker-php-ext-install
+++ b/8.2/bookworm/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bookworm/zts/Dockerfile
+++ b/8.2/bookworm/zts/Dockerfile
@@ -224,6 +224,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bookworm/zts/docker-php-ext-install
+++ b/8.2/bookworm/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bullseye/apache/Dockerfile
+++ b/8.2/bullseye/apache/Dockerfile
@@ -278,6 +278,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bullseye/apache/docker-php-ext-install
+++ b/8.2/bullseye/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bullseye/cli/Dockerfile
+++ b/8.2/bullseye/cli/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bullseye/cli/docker-php-ext-install
+++ b/8.2/bullseye/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bullseye/fpm/Dockerfile
+++ b/8.2/bullseye/fpm/Dockerfile
@@ -221,6 +221,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bullseye/fpm/docker-php-ext-install
+++ b/8.2/bullseye/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.2/bullseye/zts/Dockerfile
+++ b/8.2/bullseye/zts/Dockerfile
@@ -224,6 +224,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.2/bullseye/zts/docker-php-ext-install
+++ b/8.2/bullseye/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/alpine3.21/cli/Dockerfile
+++ b/8.3-rc/alpine3.21/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/alpine3.21/cli/docker-php-ext-install
+++ b/8.3-rc/alpine3.21/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/alpine3.21/fpm/Dockerfile
+++ b/8.3-rc/alpine3.21/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/alpine3.21/fpm/docker-php-ext-install
+++ b/8.3-rc/alpine3.21/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/alpine3.21/zts/Dockerfile
+++ b/8.3-rc/alpine3.21/zts/Dockerfile
@@ -203,6 +203,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/alpine3.21/zts/docker-php-ext-install
+++ b/8.3-rc/alpine3.21/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/alpine3.22/cli/Dockerfile
+++ b/8.3-rc/alpine3.22/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/alpine3.22/cli/docker-php-ext-install
+++ b/8.3-rc/alpine3.22/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/alpine3.22/fpm/Dockerfile
+++ b/8.3-rc/alpine3.22/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/alpine3.22/fpm/docker-php-ext-install
+++ b/8.3-rc/alpine3.22/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/alpine3.22/zts/Dockerfile
+++ b/8.3-rc/alpine3.22/zts/Dockerfile
@@ -203,6 +203,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/alpine3.22/zts/docker-php-ext-install
+++ b/8.3-rc/alpine3.22/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bookworm/apache/Dockerfile
+++ b/8.3-rc/bookworm/apache/Dockerfile
@@ -276,6 +276,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bookworm/apache/docker-php-ext-install
+++ b/8.3-rc/bookworm/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bookworm/cli/Dockerfile
+++ b/8.3-rc/bookworm/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bookworm/cli/docker-php-ext-install
+++ b/8.3-rc/bookworm/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bookworm/fpm/Dockerfile
+++ b/8.3-rc/bookworm/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bookworm/fpm/docker-php-ext-install
+++ b/8.3-rc/bookworm/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bookworm/zts/Dockerfile
+++ b/8.3-rc/bookworm/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bookworm/zts/docker-php-ext-install
+++ b/8.3-rc/bookworm/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bullseye/apache/Dockerfile
+++ b/8.3-rc/bullseye/apache/Dockerfile
@@ -274,6 +274,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bullseye/apache/docker-php-ext-install
+++ b/8.3-rc/bullseye/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bullseye/cli/Dockerfile
+++ b/8.3-rc/bullseye/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bullseye/cli/docker-php-ext-install
+++ b/8.3-rc/bullseye/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bullseye/fpm/Dockerfile
+++ b/8.3-rc/bullseye/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bullseye/fpm/docker-php-ext-install
+++ b/8.3-rc/bullseye/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3-rc/bullseye/zts/Dockerfile
+++ b/8.3-rc/bullseye/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3-rc/bullseye/zts/docker-php-ext-install
+++ b/8.3-rc/bullseye/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/alpine3.21/cli/Dockerfile
+++ b/8.3/alpine3.21/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/alpine3.21/cli/docker-php-ext-install
+++ b/8.3/alpine3.21/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/alpine3.21/fpm/Dockerfile
+++ b/8.3/alpine3.21/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/alpine3.21/fpm/docker-php-ext-install
+++ b/8.3/alpine3.21/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/alpine3.21/zts/Dockerfile
+++ b/8.3/alpine3.21/zts/Dockerfile
@@ -203,6 +203,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/alpine3.21/zts/docker-php-ext-install
+++ b/8.3/alpine3.21/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/alpine3.22/cli/Dockerfile
+++ b/8.3/alpine3.22/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/alpine3.22/cli/docker-php-ext-install
+++ b/8.3/alpine3.22/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/alpine3.22/fpm/Dockerfile
+++ b/8.3/alpine3.22/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/alpine3.22/fpm/docker-php-ext-install
+++ b/8.3/alpine3.22/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/alpine3.22/zts/Dockerfile
+++ b/8.3/alpine3.22/zts/Dockerfile
@@ -211,6 +211,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/alpine3.22/zts/docker-php-ext-install
+++ b/8.3/alpine3.22/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bookworm/apache/Dockerfile
+++ b/8.3/bookworm/apache/Dockerfile
@@ -276,6 +276,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bookworm/apache/docker-php-ext-install
+++ b/8.3/bookworm/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bookworm/cli/Dockerfile
+++ b/8.3/bookworm/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bookworm/cli/docker-php-ext-install
+++ b/8.3/bookworm/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bookworm/fpm/Dockerfile
+++ b/8.3/bookworm/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bookworm/fpm/docker-php-ext-install
+++ b/8.3/bookworm/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bookworm/zts/Dockerfile
+++ b/8.3/bookworm/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bookworm/zts/docker-php-ext-install
+++ b/8.3/bookworm/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bullseye/apache/Dockerfile
+++ b/8.3/bullseye/apache/Dockerfile
@@ -274,6 +274,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bullseye/apache/docker-php-ext-install
+++ b/8.3/bullseye/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bullseye/cli/Dockerfile
+++ b/8.3/bullseye/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bullseye/cli/docker-php-ext-install
+++ b/8.3/bullseye/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bullseye/fpm/Dockerfile
+++ b/8.3/bullseye/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bullseye/fpm/docker-php-ext-install
+++ b/8.3/bullseye/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.3/bullseye/zts/Dockerfile
+++ b/8.3/bullseye/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.3/bullseye/zts/docker-php-ext-install
+++ b/8.3/bullseye/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/alpine3.21/cli/Dockerfile
+++ b/8.4-rc/alpine3.21/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/alpine3.21/cli/docker-php-ext-install
+++ b/8.4-rc/alpine3.21/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/alpine3.21/fpm/Dockerfile
+++ b/8.4-rc/alpine3.21/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/alpine3.21/fpm/docker-php-ext-install
+++ b/8.4-rc/alpine3.21/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/alpine3.21/zts/Dockerfile
+++ b/8.4-rc/alpine3.21/zts/Dockerfile
@@ -203,6 +203,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/alpine3.21/zts/docker-php-ext-install
+++ b/8.4-rc/alpine3.21/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/alpine3.22/cli/Dockerfile
+++ b/8.4-rc/alpine3.22/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/alpine3.22/cli/docker-php-ext-install
+++ b/8.4-rc/alpine3.22/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/alpine3.22/fpm/Dockerfile
+++ b/8.4-rc/alpine3.22/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/alpine3.22/fpm/docker-php-ext-install
+++ b/8.4-rc/alpine3.22/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/alpine3.22/zts/Dockerfile
+++ b/8.4-rc/alpine3.22/zts/Dockerfile
@@ -203,6 +203,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/alpine3.22/zts/docker-php-ext-install
+++ b/8.4-rc/alpine3.22/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bookworm/apache/Dockerfile
+++ b/8.4-rc/bookworm/apache/Dockerfile
@@ -276,6 +276,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bookworm/apache/docker-php-ext-install
+++ b/8.4-rc/bookworm/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bookworm/cli/Dockerfile
+++ b/8.4-rc/bookworm/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bookworm/cli/docker-php-ext-install
+++ b/8.4-rc/bookworm/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bookworm/fpm/Dockerfile
+++ b/8.4-rc/bookworm/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bookworm/fpm/docker-php-ext-install
+++ b/8.4-rc/bookworm/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bookworm/zts/Dockerfile
+++ b/8.4-rc/bookworm/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bookworm/zts/docker-php-ext-install
+++ b/8.4-rc/bookworm/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bullseye/apache/Dockerfile
+++ b/8.4-rc/bullseye/apache/Dockerfile
@@ -274,6 +274,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bullseye/apache/docker-php-ext-install
+++ b/8.4-rc/bullseye/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bullseye/cli/Dockerfile
+++ b/8.4-rc/bullseye/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bullseye/cli/docker-php-ext-install
+++ b/8.4-rc/bullseye/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bullseye/fpm/Dockerfile
+++ b/8.4-rc/bullseye/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bullseye/fpm/docker-php-ext-install
+++ b/8.4-rc/bullseye/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4-rc/bullseye/zts/Dockerfile
+++ b/8.4-rc/bullseye/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4-rc/bullseye/zts/docker-php-ext-install
+++ b/8.4-rc/bullseye/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/alpine3.21/cli/Dockerfile
+++ b/8.4/alpine3.21/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/alpine3.21/cli/docker-php-ext-install
+++ b/8.4/alpine3.21/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/alpine3.21/fpm/Dockerfile
+++ b/8.4/alpine3.21/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/alpine3.21/fpm/docker-php-ext-install
+++ b/8.4/alpine3.21/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/alpine3.21/zts/Dockerfile
+++ b/8.4/alpine3.21/zts/Dockerfile
@@ -203,6 +203,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/alpine3.21/zts/docker-php-ext-install
+++ b/8.4/alpine3.21/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/alpine3.22/cli/Dockerfile
+++ b/8.4/alpine3.22/cli/Dockerfile
@@ -196,6 +196,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/alpine3.22/cli/docker-php-ext-install
+++ b/8.4/alpine3.22/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/alpine3.22/fpm/Dockerfile
+++ b/8.4/alpine3.22/fpm/Dockerfile
@@ -201,6 +201,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/alpine3.22/fpm/docker-php-ext-install
+++ b/8.4/alpine3.22/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/alpine3.22/zts/Dockerfile
+++ b/8.4/alpine3.22/zts/Dockerfile
@@ -211,6 +211,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/alpine3.22/zts/docker-php-ext-install
+++ b/8.4/alpine3.22/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bookworm/apache/Dockerfile
+++ b/8.4/bookworm/apache/Dockerfile
@@ -276,6 +276,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bookworm/apache/docker-php-ext-install
+++ b/8.4/bookworm/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bookworm/cli/Dockerfile
+++ b/8.4/bookworm/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bookworm/cli/docker-php-ext-install
+++ b/8.4/bookworm/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bookworm/fpm/Dockerfile
+++ b/8.4/bookworm/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bookworm/fpm/docker-php-ext-install
+++ b/8.4/bookworm/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bookworm/zts/Dockerfile
+++ b/8.4/bookworm/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bookworm/zts/docker-php-ext-install
+++ b/8.4/bookworm/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bullseye/apache/Dockerfile
+++ b/8.4/bullseye/apache/Dockerfile
@@ -274,6 +274,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bullseye/apache/docker-php-ext-install
+++ b/8.4/bullseye/apache/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bullseye/cli/Dockerfile
+++ b/8.4/bullseye/cli/Dockerfile
@@ -215,6 +215,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bullseye/cli/docker-php-ext-install
+++ b/8.4/bullseye/cli/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bullseye/fpm/Dockerfile
+++ b/8.4/bullseye/fpm/Dockerfile
@@ -217,6 +217,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bullseye/fpm/docker-php-ext-install
+++ b/8.4/bullseye/fpm/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/8.4/bullseye/zts/Dockerfile
+++ b/8.4/bullseye/zts/Dockerfile
@@ -219,6 +219,9 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/8.4/bullseye/zts/docker-php-ext-install
+++ b/8.4/bullseye/zts/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -516,6 +516,11 @@ RUN set -eux; \
 
 COPY docker-php-ext-* docker-php-entrypoint /usr/local/bin/
 
+{{ if rcVersion | IN("8.1", "8.2", "8.3", "8.4") then ( -}}
+# enable OPcache by default (https://wiki.php.net/rfc/make_opcache_required)
+RUN docker-php-ext-enable opcache
+{{ ) end -}}
+
 # sodium was built as a shared module (so that it can be replaced later if so desired), so let's enable it too (https://github.com/docker-library/php/issues/598)
 RUN docker-php-ext-enable sodium
 

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -126,7 +126,7 @@ for ext in $exts; do
 	find modules \
 		-maxdepth 1 \
 		-name '*.so' \
-		-exec basename '{}' ';' \
+		-exec basename '{}' '.so' ';' \
 			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean


### PR DESCRIPTION
OPcache is an essential part of modern PHP and will always be included in PHP starting with 8.5 (https://wiki.php.net/rfc/make_opcache_required). Enable OPcache by default in Docker to simplify the set-up.

--------------

I've verified that running `docker-php-ext-install opcache` and `docker-php-ext-enable opcache` in a custom Docker image based on the PHP image will not cause issues.