### PR TITLE
Explanation of ENV key=value adjustment

### DIFF
--- a/8.4/bookworm/apache/Dockerfile
+++ b/8.4/bookworm/apache/Dockerfile
@@ -17,16 +17,7 @@ RUN set -eux; \
 
 # dependencies required for running "phpize"
 # (see persistent deps below)
-ENV PHPIZE_DEPS \
-		autoconf \
-		dpkg-dev \
-		file \
-		g++ \
-		gcc \
-		libc-dev \
-		make \
-		pkg-config \
-		re2c
+ENV PHPIZE_DEPS="autoconf dpkg-dev file g++ gcc libc-dev make pkg-config re2c"
 
 # persistent / runtime deps
 RUN set -eux; \
@@ -39,7 +30,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV PHP_INI_DIR /usr/local/etc/php
+ENV PHP_INI_DIR=/usr/local/etc/php
 RUN set -eux; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 # allow running as an arbitrary user (https://github.com/docker-library/php/issues/743)
@@ -118,9 +109,9 @@ ENV PHP_CFLAGS="-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_
 ENV PHP_CPPFLAGS="$PHP_CFLAGS"
 ENV PHP_LDFLAGS="-Wl,-O1 -pie"
 
-ENV GPG_KEYS AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256A97AF7600A39A6 0616E93D95AF471243E26761770426E17EBBB3DD
+ENV GPG_KEYS="AFD8691FDAEDF03BDF6E460563F15A9B715376CA 9D7F99A0CB8F05C8A6958D6256A97AF7600A39A6 0616E93D95AF471243E26761770426E17EBBB3DD"
 
-ENV PHP_VERSION 8.4.12
+ENV PHP_VERSION=8.4.12
 ENV PHP_URL="https://www.php.net/distributions/php-8.4.12.tar.xz" PHP_ASC_URL="https://www.php.net/distributions/php-8.4.12.tar.xz.asc"
 ENV PHP_SHA256="c1b7978cbb5054eed6c749bde4444afc16a3f2268101fb70a7d5d9b1083b12ad"
 


### PR DESCRIPTION
📌 Explanation of ENV key=value adjustment

The Dockerfile originally used the legacy ENV key value format (with a space separator). While still functional, this syntax is considered deprecated. The recommended and modern format is ENV key=value.

Using = instead of whitespace provides several advantages:

Consistency with standard Linux environment variable assignments (KEY=value).

Clarity when setting values that may contain spaces or multiple items.

Tooling compatibility with Docker BuildKit, linters, and IDEs, which expect the modern format.

Future-proofing, since the legacy format may be removed in future Docker versions.

The container behavior does not change — the update is purely to follow best practices and eliminate warnings.