### PR TITLE
Readd www section to fpm.d/zz-docker.conf

### DIFF
--- a/8.3/alpine3.22/fpm/Dockerfile
+++ b/8.3/alpine3.22/fpm/Dockerfile
@@ -243,6 +243,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.3/alpine3.23/fpm/Dockerfile
+++ b/8.3/alpine3.23/fpm/Dockerfile
@@ -243,6 +243,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.3/bookworm/fpm/Dockerfile
+++ b/8.3/bookworm/fpm/Dockerfile
@@ -260,6 +260,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.3/trixie/fpm/Dockerfile
+++ b/8.3/trixie/fpm/Dockerfile
@@ -260,6 +260,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.4/alpine3.22/fpm/Dockerfile
+++ b/8.4/alpine3.22/fpm/Dockerfile
@@ -243,6 +243,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.4/alpine3.23/fpm/Dockerfile
+++ b/8.4/alpine3.23/fpm/Dockerfile
@@ -243,6 +243,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.4/bookworm/fpm/Dockerfile
+++ b/8.4/bookworm/fpm/Dockerfile
@@ -260,6 +260,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.4/trixie/fpm/Dockerfile
+++ b/8.4/trixie/fpm/Dockerfile
@@ -260,6 +260,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.5/alpine3.22/fpm/Dockerfile
+++ b/8.5/alpine3.22/fpm/Dockerfile
@@ -240,6 +240,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.5/alpine3.23/fpm/Dockerfile
+++ b/8.5/alpine3.23/fpm/Dockerfile
@@ -240,6 +240,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.5/bookworm/fpm/Dockerfile
+++ b/8.5/bookworm/fpm/Dockerfile
@@ -257,6 +257,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/8.5/trixie/fpm/Dockerfile
+++ b/8.5/trixie/fpm/Dockerfile
@@ -257,6 +257,9 @@ RUN set -eux; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \
 	{ \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -546,6 +546,10 @@ RUN set -eux; \
 		echo; \
 		echo '[www]'; \
 		echo 'listen = 9000'; \
+{{ ) elif env.version | IN("8.2", "8.3", "8.4", "8.5") then ( -}}
+		echo; \
+		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
+		echo '[www]'; \
 {{ ) else "" end -}}
 	} | tee php-fpm.d/zz-docker.conf; \
 	mkdir -p "$PHP_INI_DIR/conf.d"; \


### PR DESCRIPTION
Users have been relying on `zz-docker.conf` ending with a `[www]` section and have been just appending config to the file. This fixes it for them.

Fixes https://github.com/docker-library/php/issues/1646

I'm open to changing when this backwards compatibility will be removed. I've written it to not include the `[www]` section starting with 8.6 and above, but this can be changed to a later release if that makes sense.