### PR TITLE
Docs: Fix typo in Dockerfile comment

### DIFF
--- a/8.3/alpine3.22/fpm/Dockerfile
+++ b/8.3/alpine3.22/fpm/Dockerfile
@@ -237,7 +237,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.3/alpine3.23/fpm/Dockerfile
+++ b/8.3/alpine3.23/fpm/Dockerfile
@@ -237,7 +237,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.3/bookworm/fpm/Dockerfile
+++ b/8.3/bookworm/fpm/Dockerfile
@@ -254,7 +254,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.3/trixie/fpm/Dockerfile
+++ b/8.3/trixie/fpm/Dockerfile
@@ -254,7 +254,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.4/alpine3.22/fpm/Dockerfile
+++ b/8.4/alpine3.22/fpm/Dockerfile
@@ -237,7 +237,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.4/alpine3.23/fpm/Dockerfile
+++ b/8.4/alpine3.23/fpm/Dockerfile
@@ -237,7 +237,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.4/bookworm/fpm/Dockerfile
+++ b/8.4/bookworm/fpm/Dockerfile
@@ -254,7 +254,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.4/trixie/fpm/Dockerfile
+++ b/8.4/trixie/fpm/Dockerfile
@@ -254,7 +254,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.5/alpine3.22/fpm/Dockerfile
+++ b/8.5/alpine3.22/fpm/Dockerfile
@@ -234,7 +234,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.5/alpine3.23/fpm/Dockerfile
+++ b/8.5/alpine3.23/fpm/Dockerfile
@@ -234,7 +234,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.5/bookworm/fpm/Dockerfile
+++ b/8.5/bookworm/fpm/Dockerfile
@@ -251,7 +251,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/8.5/trixie/fpm/Dockerfile
+++ b/8.5/trixie/fpm/Dockerfile
@@ -251,7 +251,7 @@ RUN set -eux; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 	} | tee php-fpm.d/docker.conf; \
 	{ \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -535,7 +535,7 @@ RUN set -eux; \
 		echo 'decorate_workers_output = no'; \
 {{ if .version | IN("8.2.30", "8.3.29", "8.4.16", "8.5.1") then "" else ( -}}
 		echo; \
-		echo '; default listen adddress for easy override in later php-fpm.d/*.conf files'; \
+		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
 {{ ) end -}}
 	} | tee php-fpm.d/docker.conf; \


### PR DESCRIPTION
Corrected "adddress" to "address" in a comment regarding FPM configuration.