### PR TITLE
Drop `--with-pear` with PHP 8.6

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -28,6 +28,10 @@
 		env.variant == "zts" # only needed for ZTS builds
 		and is_alpine
 		and IN(rcVersion; "8.2")
+	;
+	def install_pear_pecl:
+		# https://github.com/docker-library/php/issues/1554
+		IN(rcVersion; "8.2", "8.3", "8.4", "8.5")
 -}}
 FROM {{ env.from }}
 
@@ -350,8 +354,10 @@ RUN set -eux; \
 # https://github.com/docker-library/php/issues/822
 		--with-pic \
 		\
+{{ if install_pear_pecl then ( -}}
 # --enable-mbstring is included here because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
 		--enable-mbstring \
+{{ ) else "" end -}}
 # --enable-mysqlnd is included here because it's harder to compile after the fact than extensions are (since it's a plugin for several extensions, not an extension in itself)
 		--enable-mysqlnd \
 # https://wiki.php.net/rfc/argon2_password_hash
@@ -377,9 +383,11 @@ RUN set -eux; \
 		--disable-phpdbg \
 {{ ) end -}}
 		\
+{{ if install_pear_pecl then ( -}}
 # in PHP 7.4+, the pecl/pear installers are officially deprecated (requiring an explicit "--with-pear")
 		--with-pear \
 		\
+{{ ) else "" end -}}
 {{ if rcVersion | IN("8.2") then ( -}}
 # bundled pcre does not support JIT on riscv64 until 10.41 (php 8.3+)
 # https://github.com/PCRE2Project/pcre2/commits/pcre2-10.41/src/sljit/sljitNativeRISCV_64.c
@@ -476,10 +484,12 @@ RUN set -eux; \
 	{{ clean_apt }}; \
 {{ ) end -}}
 	\
+{{ if install_pear_pecl then ( -}}
 # update pecl channel definitions https://github.com/docker-library/php/issues/443
 	pecl update-channels; \
 	rm -rf /tmp/pear ~/.pearrc; \
 	\
+{{ ) else "" end -}}
 # smoke test
 	php --version
 

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -284,7 +284,7 @@ RUN set -eux; \
 			# https://github.com/docker-library/php/issues/888
 			"linux-headers",
 			# oniguruma is part of mbstring in php 7.4+
-			"oniguruma-dev"
+			if install_pear_pecl then "oniguruma-dev" else empty end
 		else
 			# debian packages
 			if env.variant == "apache" then "apache2-dev" else empty end,
@@ -297,7 +297,7 @@ RUN set -eux; \
 			"libxml2-dev",
 			"zlib1g-dev",
 			# oniguruma is part of mbstring in php 7.4+
-			"libonig-dev"
+			if install_pear_pecl then "libonig-dev" else empty end
 		end ] | sort[] | (
 -}}
 		{{ . }} \


### PR DESCRIPTION
Even if we don't adopt PIE in the upstream PHP image (because https://github.com/docker-library/php/issues/1554#issuecomment-3722916430 “just works”), we should stop shipping the PECL binary with PHP 8.6.

see docker-library/php#1554