### PR TITLE
Handle built-in extensions in docker-php-ext-install

### DIFF
--- a/8.2/alpine3.22/cli/docker-php-ext-install
+++ b/8.2/alpine3.22/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/alpine3.22/fpm/docker-php-ext-install
+++ b/8.2/alpine3.22/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/alpine3.22/zts/docker-php-ext-install
+++ b/8.2/alpine3.22/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/alpine3.23/cli/docker-php-ext-install
+++ b/8.2/alpine3.23/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/alpine3.23/fpm/docker-php-ext-install
+++ b/8.2/alpine3.23/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/alpine3.23/zts/docker-php-ext-install
+++ b/8.2/alpine3.23/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/bookworm/apache/docker-php-ext-install
+++ b/8.2/bookworm/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/bookworm/cli/docker-php-ext-install
+++ b/8.2/bookworm/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/bookworm/fpm/docker-php-ext-install
+++ b/8.2/bookworm/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/bookworm/zts/docker-php-ext-install
+++ b/8.2/bookworm/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/trixie/apache/docker-php-ext-install
+++ b/8.2/trixie/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/trixie/cli/docker-php-ext-install
+++ b/8.2/trixie/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/trixie/fpm/docker-php-ext-install
+++ b/8.2/trixie/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.2/trixie/zts/docker-php-ext-install
+++ b/8.2/trixie/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/alpine3.22/cli/docker-php-ext-install
+++ b/8.3/alpine3.22/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/alpine3.22/fpm/docker-php-ext-install
+++ b/8.3/alpine3.22/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/alpine3.22/zts/docker-php-ext-install
+++ b/8.3/alpine3.22/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/alpine3.23/cli/docker-php-ext-install
+++ b/8.3/alpine3.23/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/alpine3.23/fpm/docker-php-ext-install
+++ b/8.3/alpine3.23/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/alpine3.23/zts/docker-php-ext-install
+++ b/8.3/alpine3.23/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/bookworm/apache/docker-php-ext-install
+++ b/8.3/bookworm/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/bookworm/cli/docker-php-ext-install
+++ b/8.3/bookworm/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/bookworm/fpm/docker-php-ext-install
+++ b/8.3/bookworm/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/bookworm/zts/docker-php-ext-install
+++ b/8.3/bookworm/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/trixie/apache/docker-php-ext-install
+++ b/8.3/trixie/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/trixie/cli/docker-php-ext-install
+++ b/8.3/trixie/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/trixie/fpm/docker-php-ext-install
+++ b/8.3/trixie/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.3/trixie/zts/docker-php-ext-install
+++ b/8.3/trixie/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/alpine3.22/cli/docker-php-ext-install
+++ b/8.4/alpine3.22/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/alpine3.22/fpm/docker-php-ext-install
+++ b/8.4/alpine3.22/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/alpine3.22/zts/docker-php-ext-install
+++ b/8.4/alpine3.22/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/alpine3.23/cli/docker-php-ext-install
+++ b/8.4/alpine3.23/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/alpine3.23/fpm/docker-php-ext-install
+++ b/8.4/alpine3.23/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/alpine3.23/zts/docker-php-ext-install
+++ b/8.4/alpine3.23/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/bookworm/apache/docker-php-ext-install
+++ b/8.4/bookworm/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/bookworm/cli/docker-php-ext-install
+++ b/8.4/bookworm/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/bookworm/fpm/docker-php-ext-install
+++ b/8.4/bookworm/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/bookworm/zts/docker-php-ext-install
+++ b/8.4/bookworm/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/trixie/apache/docker-php-ext-install
+++ b/8.4/trixie/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/trixie/cli/docker-php-ext-install
+++ b/8.4/trixie/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/trixie/fpm/docker-php-ext-install
+++ b/8.4/trixie/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.4/trixie/zts/docker-php-ext-install
+++ b/8.4/trixie/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/alpine3.22/cli/docker-php-ext-install
+++ b/8.5/alpine3.22/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/alpine3.22/fpm/docker-php-ext-install
+++ b/8.5/alpine3.22/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/alpine3.22/zts/docker-php-ext-install
+++ b/8.5/alpine3.22/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/alpine3.23/cli/docker-php-ext-install
+++ b/8.5/alpine3.23/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/alpine3.23/fpm/docker-php-ext-install
+++ b/8.5/alpine3.23/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/alpine3.23/zts/docker-php-ext-install
+++ b/8.5/alpine3.23/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/bookworm/apache/docker-php-ext-install
+++ b/8.5/bookworm/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/bookworm/cli/docker-php-ext-install
+++ b/8.5/bookworm/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/bookworm/fpm/docker-php-ext-install
+++ b/8.5/bookworm/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/bookworm/zts/docker-php-ext-install
+++ b/8.5/bookworm/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/trixie/apache/docker-php-ext-install
+++ b/8.5/trixie/apache/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/trixie/cli/docker-php-ext-install
+++ b/8.5/trixie/cli/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/trixie/fpm/docker-php-ext-install
+++ b/8.5/trixie/fpm/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/8.5/trixie/zts/docker-php-ext-install
+++ b/8.5/trixie/zts/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 

--- a/docker-php-ext-install
+++ b/docker-php-ext-install
@@ -41,6 +41,24 @@ usage() {
 	echo 'the output of "php -i" to see which modules are already loaded.'
 }
 
+phpModuleLoaded() {
+	php -d 'display_errors=stderr' -r '
+		$ext = strtolower($argv[1]);
+		$loaded = array_map("strtolower", get_loaded_extensions());
+		$loaded = array_merge($loaded, array_map("strtolower", get_loaded_extensions(true)));
+		$aliases = [
+			"opcache" => ["zend opcache"],
+		];
+		$needles = array_merge([$ext], $aliases[$ext] ?? []);
+		foreach ($needles as $needle) {
+			if (in_array($needle, $loaded, true)) {
+				exit(0);
+			}
+		}
+		exit(1);
+	' -- "$1"
+}
+
 opts="$(getopt -o 'h?j:' --long 'help,ini-name:,jobs:' -- "$@" || { usage >&2 && false; })"
 eval set -- "$opts"
 
@@ -108,6 +126,22 @@ for ext in $exts; do
 
 	make -j"$j"
 
+	modules="$(find modules \
+		-maxdepth 1 \
+		-name '*.so' \
+		-print \
+	)"
+	if [ -z "$modules" ]; then
+		if phpModuleLoaded "$ext"; then
+			echo >&2
+			echo >&2 "warning: $ext is already built into PHP; skipping installation"
+			echo >&2
+			make -j"$j" clean
+			cd "$popDir"
+			continue
+		fi
+	fi
+
 	if ! php -n -d 'display_errors=stderr' -r 'exit(ZEND_DEBUG_BUILD ? 0 : 1);' > /dev/null; then
 		# only "strip" modules if we aren't using a debug build of PHP
 		# (none of our builds are debug builds, but PHP might be recompiled with "--enable-debug" configure option)
@@ -123,11 +157,10 @@ for ext in $exts; do
 
 	make -j"$j" install
 
-	find modules \
-		-maxdepth 1 \
-		-name '*.so' \
-		-exec basename '{}' '.so' ';' \
-			| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
+	printf '%s\n' "$modules" \
+		| xargs -r -n1 basename \
+		| sed 's/\.so$//' \
+		| xargs -r docker-php-ext-enable ${iniName:+--ini-name "$iniName"}
 
 	make -j"$j" clean
 


### PR DESCRIPTION
## Summary
`docker-php-ext-install` currently assumes every successful extension build produces a shared `.so` file. On PHP 8.5, `opcache` may already be built into PHP, so `docker-php-ext-install opcache` can fail even though the extension is already available.

## Changes
- detect when a requested extension is already built into PHP
- skip install/enable for built-in extensions with a clear warning
- preserve existing behavior for normal shared-module installs
- sync the updated installer into generated version directories

## Why
This makes `docker-php-ext-install` more robust for built-in extensions such as OPcache on PHP 8.5, avoiding failures when no loadable module artifact is produced.

## Validation
- ran `sh -n` on the updated `docker-php-ext-install` script
- ran `sh -n` across all synced generated copies
