### PR TITLE
Remove temporary limiting code from #1635

### DIFF
--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -533,20 +533,14 @@ RUN set -eux; \
 		echo '; Ensure worker stdout and stderr are sent to the main error log.'; \
 		echo 'catch_workers_output = yes'; \
 		echo 'decorate_workers_output = no'; \
-{{ if .version | IN("8.2.30", "8.3.29", "8.4.16", "8.5.1") then "" else ( -}}
 		echo; \
 		echo '; default listen address for easy override in later php-fpm.d/*.conf files'; \
 		echo 'listen = 9000'; \
-{{ ) end -}}
 	} | tee php-fpm.d/docker.conf; \
 	{ \
 		echo '[global]'; \
 		echo 'daemonize = no'; \
-{{ if .version | IN("8.2.30", "8.3.29", "8.4.16", "8.5.1") then ( -}}
-		echo; \
-		echo '[www]'; \
-		echo 'listen = 9000'; \
-{{ ) elif rcVersion | IN("8.2", "8.3", "8.4", "8.5") then ( -}}
+{{ if rcVersion | IN("8.2", "8.3", "8.4", "8.5") then ( -}}
 		echo; \
 		echo '; the [www] ini section below is for backwards compatibility and will be removed in 8.6+'; \
 		echo '[www]'; \


### PR DESCRIPTION
With the update to 8.2.31 in f4e930a76363da0b3b2f034d8ffc0532b1f8e61a this is now obsolete.

Edit: follow up for https://github.com/docker-library/php/pull/1635