### PR TITLE
Update pre-releases api url

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -33,7 +33,7 @@ for version in "${versions[@]}"; do
 			) ]
 		'
 	else
-		apiUrl='https://www.php.net/release-candidates.php?format=json'
+		apiUrl='https://www.php.net/pre-release-builds.php?format=json'
 		apiJqExpr='
 			(.releases // [])[]
 			| select(.version | startswith(env.rcVersion))


### PR DESCRIPTION
`php.net` does have a [redirect](https://github.com/php/web-php/blob/b204458bce041b7525be12ab2fa49d4a7369bfe9/error.php#L576) from `release-candidates` to `pre-release-builds`, but it stopped passing along query parameters on the 19th of June (but I don't see a code change that causes it). So, we'll just use the newer route.

Without this, the update.sh job fails with the following:
```console
jq: parse error: Invalid numeric literal at line 1, column 10
curl: (23) Failure writing output to destination, passed 8192 returned 0
```

testing
```console
$ curl -fsSL https://www.php.net/release-candidates.php?format=json | head -n2
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
$ curl -fsSL https://www.php.net/pre-release-builds.php?format=json | jq | head -n2
{
  "8.2.27": {
```