### PR TITLE
Skip arm32v6 on 8.6.0alpha2 (and alpha3)

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -144,6 +144,17 @@ for version; do
 		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$dir/Dockerfile")"
 		variantArches="${parentRepoToArches[$variantParent]}"
 
+		# php segfaults on arm32v6 for these pre-releases
+		# https://github.com/docker-library/php/issues/1675
+		if [[ "$suite" =~ 'alpine'* ]]; then
+			if [[ "$fullVersion" == '8.6.0alpha'[23] ]]; then
+				variantArches="$(jq <<<"$variantArches" --raw-input --raw-output '
+					split(" ") - [ "arm32v6" ]
+					| join(" ")
+				')"
+			fi
+		fi
+
 		commit="$(dirCommit "$dir")"
 
 		echo


### PR DESCRIPTION
For now, skip failing builds on arm32v6. See https://github.com/docker-library/php/issues/1675

`8.6.0alpha3` also fails. It has a tag, but no release `tar.xz` on [php.net](https://www.php.net/pre-release-builds.php?format=json) so I tested the tag's "source code tar.gz".

```
Generating phar.php
make: [Makefile:379: ext/phar/phar.php] Segmentation fault (core dumped) (ignored)
Generating phar.phar
Segmentation fault (core dumped)
[...]
+ php --version
[...] did not complete successfully: exit code: 139
```
(exit 139 = 128 +11 -> segfault)


```diff
 $ diff -u ../official-images/library/php <(./generate-stackbrew-library.sh)
--- ../official-images/library/php      2026-07-20 10:48:53.176116092 -0700
+++ /dev/fd/63  2026-07-29 15:34:55.650998226 -0700
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/php/blob/6c91a369458bf48ae137a647934585ce0480067d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/827b8643e362d94c2b9e9d2a29b074a24b87fe69/generate-stackbrew-library.sh

 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -45,32 +45,32 @@
 Directory: 8.6-rc/bookworm/zts

 Tags: 8.6.0alpha2-cli-alpine3.24, 8.6-rc-cli-alpine3.24, 8.6.0alpha2-alpine3.24, 8.6-rc-alpine3.24, 8.6.0alpha2-cli-alpine, 8.6-rc-cli-alpine, 8.6.0alpha2-alpine, 8.6-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 77c06cf7579bfc5cdf4542a67591ede7e86f8491
 Directory: 8.6-rc/alpine3.24/cli

 Tags: 8.6.0alpha2-fpm-alpine3.24, 8.6-rc-fpm-alpine3.24, 8.6.0alpha2-fpm-alpine, 8.6-rc-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 77c06cf7579bfc5cdf4542a67591ede7e86f8491
 Directory: 8.6-rc/alpine3.24/fpm

 Tags: 8.6.0alpha2-zts-alpine3.24, 8.6-rc-zts-alpine3.24, 8.6.0alpha2-zts-alpine, 8.6-rc-zts-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 77c06cf7579bfc5cdf4542a67591ede7e86f8491
 Directory: 8.6-rc/alpine3.24/zts

 Tags: 8.6.0alpha2-cli-alpine3.23, 8.6-rc-cli-alpine3.23, 8.6.0alpha2-alpine3.23, 8.6-rc-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 77c06cf7579bfc5cdf4542a67591ede7e86f8491
 Directory: 8.6-rc/alpine3.23/cli

 Tags: 8.6.0alpha2-fpm-alpine3.23, 8.6-rc-fpm-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 77c06cf7579bfc5cdf4542a67591ede7e86f8491
 Directory: 8.6-rc/alpine3.23/fpm

 Tags: 8.6.0alpha2-zts-alpine3.23, 8.6-rc-zts-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 77c06cf7579bfc5cdf4542a67591ede7e86f8491
 Directory: 8.6-rc/alpine3.23/zts
```