### PR TITLE
Add a `cachebuster=` argument to API requests

### DIFF
--- a/versions.sh
+++ b/versions.sh
@@ -14,6 +14,8 @@ else
 fi
 versions=( "${versions[@]%/}" )
 
+now="$(date --utc '+%s')"
+
 for version in "${versions[@]}"; do
 	rcVersion="${version%-rc}"
 	export version rcVersion
@@ -45,6 +47,7 @@ for version in "${versions[@]}"; do
 			]
 		'
 	fi
+	apiUrl+="&cachebuster=$now" # combat over-aggressive cache on php.net
 	IFS=$'\n'
 	possibles=( $(
 		curl -fsSL "$apiUrl" \


### PR DESCRIPTION
This avoids over-aggressive caches:

```diff
$ diff -u \
  <(curl -fsSL 'https://www.php.net/releases/index.php?json&max=100&version=8' | jq 'keys_unsorted') \
  <(curl -fsSL 'https://www.php.net/releases/index.php?json&max=100&version=8' -H 'accept-language: en-US,en;q=0.9' | jq 'keys_unsorted')
--- /dev/fd/63	2026-07-30 14:37:22.845857517 -0700
+++ /dev/fd/62	2026-07-30 14:37:22.845857517 -0700
@@ -1,7 +1,11 @@
 [
-  "8.5.8",
+  "8.5.9",
+  "8.4.24",
+  "8.3.33",
+  "8.2.33",
   "8.4.23",
   "8.3.32",
+  "8.5.8",
   "8.2.32",
   "8.5.7",
   "8.4.22",
@@ -94,9 +98,5 @@
   "8.1.25",
   "8.2.12",
   "8.1.24",
-  "8.2.11",
-  "8.1.23",
-  "8.2.10",
-  "8.1.22",
-  "8.2.9"
+  "8.2.11"
 ]
```

- https://github.com/docker-library/official-images/pull/21958#issuecomment-5136347248